### PR TITLE
Added aws.service and aws.region attributes

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -44,6 +44,7 @@ function wrapMakeRequest(shim, fn, name, request) {
   }
 
   const service = getServiceName(this)
+  const region = this.config && this.config.region
   request.on('complete', function onAwsRequestComplete() {
     const httpRequest = request.httpRequest && request.httpRequest.stream
     const segment = shim.getSegment(httpRequest)
@@ -57,6 +58,7 @@ function wrapMakeRequest(shim, fn, name, request) {
     segment.parameters['aws.operation'] = request.operation || UNKNOWN
     segment.parameters['aws.requestId'] = requestId || UNKNOWN
     segment.parameters['aws.service'] = service || UNKNOWN
+    segment.parameters['aws.region'] = region || UNKNOWN
   })
 }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -43,6 +43,7 @@ function wrapMakeRequest(shim, fn, name, request) {
     return
   }
 
+  const service = getServiceName(this)
   request.on('complete', function onAwsRequestComplete() {
     const httpRequest = request.httpRequest && request.httpRequest.stream
     const segment = shim.getSegment(httpRequest)
@@ -55,10 +56,24 @@ function wrapMakeRequest(shim, fn, name, request) {
 
     segment.parameters['aws.operation'] = request.operation || UNKNOWN
     segment.parameters['aws.requestId'] = requestId || UNKNOWN
-
-    // TODO: Extract service name somehow.
-    // segment.parameters['aws.service'] = ???
+    segment.parameters['aws.service'] = service || UNKNOWN
   })
+}
+
+function getServiceName(service) {
+  if (service.api && (service.api.abbreviation || service.api.serviceId)) {
+    return service.api.abbreviation || service.api.serviceId
+  }
+
+  // In theory, getting the `constructor.prototype` should be redundant with
+  // checking `service`. However, the aws-sdk dynamically generates classes and
+  // doing this deep check was the recommended method by the maintainers.
+  const constructor = service.constructor
+  const api = constructor && constructor.prototype && constructor.prototype.api
+  if (api) {
+    return api.abbreviation || api.serviceId
+  }
+  return null
 }
 
 module.exports = {

--- a/lib/core.js
+++ b/lib/core.js
@@ -53,12 +53,13 @@ function wrapMakeRequest(shim, fn, name, request) {
       return
     }
 
+    const requestRegion = request.httpRequest.region
     const requestId = request.response && request.response.requestId
 
     segment.parameters['aws.operation'] = request.operation || UNKNOWN
     segment.parameters['aws.requestId'] = requestId || UNKNOWN
     segment.parameters['aws.service'] = service || UNKNOWN
-    segment.parameters['aws.region'] = region || UNKNOWN
+    segment.parameters['aws.region'] = requestRegion || region || UNKNOWN
   })
 }
 

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -4,7 +4,8 @@ function checkAWSExternals(t, segment, externalSegments = []) {
   const expectedParams = {
     'aws.operation': String,
     'aws.service': String,
-    'aws.requestId': String
+    'aws.requestId': String,
+    'aws.region': String
   }
 
   if (/^External\/.*?amazonaws\.com/.test(segment.name)) {

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -3,7 +3,7 @@
 function checkAWSExternals(t, segment, externalSegments = []) {
   const expectedParams = {
     'aws.operation': String,
-    // 'aws.service': String, // TODO: Bring back the service name.
+    'aws.service': String,
     'aws.requestId': String
   }
 

--- a/tests/versioned/s3.tap.js
+++ b/tests/versioned/s3.tap.js
@@ -62,18 +62,18 @@ tap.test('S3 buckets', (t) => {
 
       t.matches(head.parameters, {
         'aws.operation': 'headBucket',
-        'aws.requestId': String
-        // 'aws.service': 'S3' // TODO: Bring back service name.
+        'aws.requestId': String,
+        'aws.service': 'Amazon S3'
       }, 'should have expected parameters')
       t.matches(create.parameters, {
         'aws.operation': 'createBucket',
-        'aws.requestId': String
-        // 'aws.service': 'S3' // TODO: Bring back service name.
+        'aws.requestId': String,
+        'aws.service': 'Amazon S3'
       }, 'should have expected parameters')
       t.matches(del.parameters, {
         'aws.operation': 'deleteBucket',
-        'aws.requestId': String
-        // 'aws.service': 'S3' // TODO: Bring back service name.
+        'aws.requestId': String,
+        'aws.service': 'Amazon S3'
       }, 'should have expected parameters')
 
       t.end()

--- a/tests/versioned/s3.tap.js
+++ b/tests/versioned/s3.tap.js
@@ -63,17 +63,20 @@ tap.test('S3 buckets', (t) => {
       t.matches(head.parameters, {
         'aws.operation': 'headBucket',
         'aws.requestId': String,
-        'aws.service': 'Amazon S3'
+        'aws.service': 'Amazon S3',
+        'aws.region': 'us-east-1'
       }, 'should have expected parameters')
       t.matches(create.parameters, {
         'aws.operation': 'createBucket',
         'aws.requestId': String,
-        'aws.service': 'Amazon S3'
+        'aws.service': 'Amazon S3',
+        'aws.region': 'us-east-1'
       }, 'should have expected parameters')
       t.matches(del.parameters, {
         'aws.operation': 'deleteBucket',
         'aws.requestId': String,
-        'aws.service': 'Amazon S3'
+        'aws.service': 'Amazon S3',
+        'aws.region': 'us-east-1'
       }, 'should have expected parameters')
 
       t.end()


### PR DESCRIPTION
Added `aws.service` and `aws.region` attributes. The second attribute is not necessary by spec yet, but was easy enough to add and python is considering it too.