### PR TITLE
dynamodb: move name prop to segment description root

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -27,8 +27,8 @@ function instrument(shim, AWS) {
       OPERATIONS,
       function wrapMethod(shim, original, name, args) {
         return {
+          name,
           parameters: {
-            name,
             host: this.endpoint.host,
             port_path_or_id: this.endpoint.port,
             database_name: args[0].TableName || 'Unknown'

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -111,12 +111,18 @@ function finish(t, tx) {
   t.equal(segments.length, 8, 'should have 8 aws datastore segments')
 
   segments.forEach((segment, i) => {
+    const operation = TESTS[i].method
+    t.equal(
+      segment.name,
+      `Datastore/operation/DynamoDB/${operation}`,
+      'should have operation in segment name'
+    )
     const attrs = segment.attributes.get(common.SEGMENT_DESTINATION)
     t.matches(attrs, {
       'host': String,
       'port_path_or_id': String,
       'database_name': String,
-      'aws.operation': TESTS[i].method,
+      'aws.operation': operation,
       'aws.requestId': String,
       'aws.region': 'us-east-1',
       'aws.service': 'DynamoDB'


### PR DESCRIPTION
## CHANGELOG

* Moved `name` property to the root of DynamoDB segment description object.

  Previously, segments were being incorrectly named `"Datastore/operation/DynamoDB/undefined"`, due to the operation name being misplaced. 
