### PR TITLE
NODE-2030 Adds DocumentClient instrumentation

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -11,17 +11,10 @@ const OPERATIONS = [
   'scan'
 ]
 
-let dynamoProtoWrapped = false
-
 function instrument(shim, AWS) {
+  shim.setDatastore(shim.DYNAMODB)
+
   shim.wrapReturn(AWS, 'DynamoDB', function wrapDynamo(shim, fn, name, ddb) {
-    if (dynamoProtoWrapped) {
-      return
-    }
-    dynamoProtoWrapped = true
-
-    shim.setDatastore(shim.DYNAMODB)
-
     shim.recordOperation(
       ddb,
       OPERATIONS,

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const OPERATIONS = [
+const DDB_OPERATIONS = [
   'putItem',
   'getItem',
   'updateItem',
@@ -11,18 +11,27 @@ const OPERATIONS = [
   'scan'
 ]
 
+const DOC_CLIENT_OPERATIONS = [
+  'get',
+  'put',
+  'update',
+  'delete',
+  'query',
+  'scan'
+]
+
 function instrument(shim, AWS) {
   shim.setDatastore(shim.DYNAMODB)
 
   shim.wrapReturn(AWS, 'DynamoDB', function wrapDynamo(shim, fn, name, ddb) {
     shim.recordOperation(
       ddb,
-      OPERATIONS,
-      function wrapMethod(shim, original, name, args) {
+      DDB_OPERATIONS,
+      function wrapMethod(shim, original, operationName, args) {
         const params = args[0]
 
         return {
-          name,
+          name: operationName,
           parameters: {
             host: this.endpoint.host,
             port_path_or_id: this.endpoint.port,
@@ -34,6 +43,35 @@ function instrument(shim, AWS) {
       }
     )
   })
+
+  // DocumentClient does defer to DynamoDB but it also does enough individual
+  // steps for the request we want to hide that instrumenting specifically and
+  // setting to opaque is required.
+  shim.wrapReturn(
+    AWS.DynamoDB,
+    'DocumentClient',
+    function wrapDocumentClient(shim, fn, name, documentClient) {
+      shim.recordOperation(
+        documentClient,
+        DOC_CLIENT_OPERATIONS,
+        function wrapOperation(shim, original, operationName, args) {
+          const params = args[0]
+          const dynamoOperation = this.serviceClientOperationsMap[operationName]
+
+          return {
+            name: dynamoOperation,
+            parameters: {
+              host: this.service.endpoint.host,
+              port_path_or_id: this.service.endpoint.port,
+              collection: params && params.TableName || 'Unknown'
+            },
+            callback: shim.LAST,
+            opaque: true
+          }
+        }
+      )
+    }
+  )
 }
 
 module.exports = {

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -23,6 +23,8 @@ const DOC_CLIENT_OPERATIONS = [
 function instrument(shim, AWS) {
   shim.setDatastore(shim.DYNAMODB)
 
+  // DynamoDB's service API methods are dynamically generated
+  // in the constructor so we have to wrap the return.
   shim.wrapReturn(AWS, 'DynamoDB', function wrapDynamo(shim, fn, name, ddb) {
     shim.recordOperation(
       ddb,
@@ -44,32 +46,28 @@ function instrument(shim, AWS) {
     )
   })
 
+  // DocumentClient's API is predefined so we can instrument the prototype.
   // DocumentClient does defer to DynamoDB but it also does enough individual
   // steps for the request we want to hide that instrumenting specifically and
-  // setting to opaque is required.
-  shim.wrapReturn(
-    AWS.DynamoDB,
-    'DocumentClient',
-    function wrapDocumentClient(shim, fn, name, documentClient) {
-      shim.recordOperation(
-        documentClient,
-        DOC_CLIENT_OPERATIONS,
-        function wrapOperation(shim, original, operationName, args) {
-          const params = args[0]
-          const dynamoOperation = this.serviceClientOperationsMap[operationName]
+  // setting to opaque is currently required.
+  const docClientProto = AWS.DynamoDB.DocumentClient.prototype
+  shim.recordOperation(
+    docClientProto,
+    DOC_CLIENT_OPERATIONS,
+    function wrapOperation(shim, original, operationName, args) {
+      const params = args[0]
+      const dynamoOperation = this.serviceClientOperationsMap[operationName]
 
-          return {
-            name: dynamoOperation,
-            parameters: {
-              host: this.service.endpoint.host,
-              port_path_or_id: this.service.endpoint.port,
-              collection: params && params.TableName || 'Unknown'
-            },
-            callback: shim.LAST,
-            opaque: true
-          }
-        }
-      )
+      return {
+        name: dynamoOperation,
+        parameters: {
+          host: this.service.endpoint.host,
+          port_path_or_id: this.service.endpoint.port,
+          collection: params && params.TableName || 'Unknown'
+        },
+        callback: shim.LAST,
+        opaque: true
+      }
     }
   )
 }


### PR DESCRIPTION
* Adds support for DocumentClient API calls to be captured as Datastore segments/metrics. 

  Supported calls are: `get`, `put`, `update`, `delete`, `query` and `scan`. These will be named according to the underlying DynamoDB operation that is executed. For example: `get` will be named `getItem`. DocumentClient calls not listed above will still be captured as Externals.

* Fixed issue that would prevent multiple DynamoDB instances from being instrumented.