### PR TITLE
NODE-2185 Drop Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "12"
 env:
   - SUITE=lint
-  - SUITE=unit
   - SUITE=versioned
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,8 @@ env:
   - SUITE=versioned
 matrix:
   exclude:
-    - node_js: "6"
-      env: SUITE=lint
-    - node_js: "7"
-      env: SUITE=lint
     - node_js: "8"
       env: SUITE=lint
-    - node_js: "9"
+    - node_js: "10"
       env: SUITE=lint
 script: npm run $SUITE

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint *.js lib tests"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* **BREAKING** Removed support for Node 6, 7, and 9.

  The minimum supported version is now Node v8. For further information on our support policy, see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.