### PR TITLE
Adds additional items to npmignore to reduce chance of deployed cruft.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 package-lock.json
 **/node_modules/**
+.nyc_output
+.vscode


### PR DESCRIPTION
* Adds `.nyc_output` and `.vscode` to `.npmignore` to reduce chance of deploying unnecessary files to npm.


------

Noticed these during dry run of the previous release.