### PR TITLE
Bumps minimum versioned node engine to 8.

### DIFF
--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -5,7 +5,7 @@
   "tests": [
     {
       "engines": {
-        "node": ">=6.0"
+        "node": ">=8.0"
       },
       "dependencies": {
         "aws-sdk": ">=2.380.0"


### PR DESCRIPTION
* Bumps minimum versioned test Node version to 8+.

----

Missed this before thinking it was captured in a different PR. I am bad and should feel bad.