### PR TITLE
Limits versioned tests to one older version and then newer versions going forward

### DIFF
--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -8,7 +8,21 @@
         "node": ">=8.0"
       },
       "dependencies": {
-        "aws-sdk": ">=2.380.0"
+        "aws-sdk": "2.380.0"
+      },
+      "files": [
+        "aws-sdk.tap.js",
+        "dynamodb.tap.js",
+        "http-services.tap.js",
+        "s3.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=8.0"
+      },
+      "dependencies": {
+        "aws-sdk": ">=2.561.0"
       },
       "files": [
         "aws-sdk.tap.js",


### PR DESCRIPTION
* Limited versioned test permutations to one older version and then new versions going forward.

This is sort of a temporary fix for how quickly `aws-sdk` pushes updates. We'll get to a large permutation again and will likely eventually want to find a solution that automatically makes sense in the versioned runner but don't want to rush that.

This is easy enough to tweak on the fly.

Choosing the one original supported version just in case there's something that changes we *might* break down the road. Otherwise, they are releasing so fast I just chose the release from today. They seem to be releasing almost every work day.