### PR TITLE
Feature Sniff for Features before Instrumenting

### DIFF
--- a/lib/instrumentation-helper.js
+++ b/lib/instrumentation-helper.js
@@ -1,0 +1,22 @@
+'use strict'
+
+/**
+ * Series of tests to determine if the library
+ * has the features needed to provide instrumentation
+ */
+const instrumentationSupported = function instrumentationSupported(AWS) {
+  // instrumentation requires the serviceClientOperationsMap property
+  if (!AWS ||
+      !AWS.DynamoDB ||
+      !AWS.DynamoDB.DocumentClient ||
+      !AWS.DynamoDB.DocumentClient.prototype ||
+      !AWS.DynamoDB.DocumentClient.prototype.serviceClientOperationsMap) {
+    return false
+  }
+
+  return true
+}
+
+module.exports = {
+  instrumentationSupported
+}

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -7,25 +7,10 @@ const INSTRUMENTATIONS = [
   require('./sns')
 ]
 
-/**
- * Series of tests to determine if the library
- * has the features needed to provide instrumentation
- */
-const instrumentationSupported = function instrumentationSupported(AWS) {
-  // instrumentation requires the serviceClientOperationsMap property
-  if (!AWS ||
-      !AWS.DynamoDB ||
-      !AWS.DynamoDB.DocumentClient ||
-      !AWS.DynamoDB.DocumentClient.prototype ||
-      !AWS.DynamoDB.DocumentClient.prototype.serviceClientOperationsMap) {
-    return false
-  }
-
-  return true
-}
+const helper = require('./instrumentation-helper')
 
 module.exports = function initialize(shim, AWS) {
-  if (!instrumentationSupported(AWS)) {
+  if (!helper.instrumentationSupported(AWS)) {
     return false
   }
   // Validate every instrumentation before attempting to run any of them.

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -7,7 +7,27 @@ const INSTRUMENTATIONS = [
   require('./sns')
 ]
 
+/**
+ * Series of tests to determine if the library
+ * has the features needed to provide instrumentation
+ */
+const instrumentationSupported = function instrumentationSupported(AWS) {
+  // instrumentation requires the serviceClientOperationsMap property
+  if (!AWS ||
+      !AWS.DynamoDB ||
+      !AWS.DynamoDB.DocumentClient ||
+      !AWS.DynamoDB.DocumentClient.prototype ||
+      !AWS.DynamoDB.DocumentClient.prototype.serviceClientOperationsMap) {
+    return false
+  }
+
+  return true
+}
+
 module.exports = function initialize(shim, AWS) {
+  if(!instrumentationSupported(AWS)) {
+    return false
+  }
   // Validate every instrumentation before attempting to run any of them.
   for (let instrumentation of INSTRUMENTATIONS) {
     if (!instrumentation.validate(shim, AWS)) {

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -25,7 +25,7 @@ const instrumentationSupported = function instrumentationSupported(AWS) {
 }
 
 module.exports = function initialize(shim, AWS) {
-  if(!instrumentationSupported(AWS)) {
+  if (!instrumentationSupported(AWS)) {
     return false
   }
   // Validate every instrumentation before attempting to run any of them.

--- a/tests/versioned/instrumentation-supported.tap.js
+++ b/tests/versioned/instrumentation-supported.tap.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const tap = require('tap')
+const utils = require('@newrelic/test-utilities')
+const instrumentationHelper = require('../../lib/instrumentation-helper')
+utils.assert.extendTap(tap)
+
+tap.test('instrumentation is supported', (t) => {
+  t.autoend()
+
+  let helper = null
+  let AWS = null
+
+  t.beforeEach((done) => {
+    helper = utils.TestAgent.makeInstrumented()
+    helper.registerInstrumentation({
+      moduleName: 'aws-sdk',
+      type: 'conglomerate',
+      onRequire: require('../../lib/instrumentation')
+    })
+    AWS = require('aws-sdk')
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper && helper.unload()
+    AWS = null
+    done()
+  })
+
+  t.test('AWS should have newrelic attributes', (t) => {
+    t.assert(AWS.__NR_instrumented, 'Found __NR_instrumented')
+    t.end()
+  })
+
+  t.test('instrumentation supported function', (t) => {
+    t.assert(
+      instrumentationHelper.instrumentationSupported(AWS),
+      'instrumentationSupported returned true'
+    )
+    t.end()
+  })
+})

--- a/tests/versioned/instrumentation-unsupported.tap.js
+++ b/tests/versioned/instrumentation-unsupported.tap.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const tap = require('tap')
+const utils = require('@newrelic/test-utilities')
+const instrumentationHelper = require('../../lib/instrumentation-helper')
+utils.assert.extendTap(tap)
+
+tap.test('instrumentation is supported', (t) => {
+  t.autoend()
+
+  let helper = null
+  let AWS = null
+
+  t.beforeEach((done) => {
+    helper = utils.TestAgent.makeInstrumented()
+    helper.registerInstrumentation({
+      moduleName: 'aws-sdk',
+      type: 'conglomerate',
+      onRequire: require('../../lib/instrumentation')
+    })
+    AWS = require('aws-sdk')
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper && helper.unload()
+    AWS = null
+    done()
+  })
+
+  t.test('AWS should not have newrelic attributes', (t) => {
+    t.assert(!AWS.__NR_instrumented, 'Found __NR_instrumented')
+    t.end()
+  })
+
+  t.test('instrumentation supported function', (t) => {
+    t.assert(
+      !instrumentationHelper.instrumentationSupported(AWS),
+      'instrumentationSupported returned false'
+    )
+    t.end()
+  })
+})

--- a/tests/versioned/instrumentation-unsupported.tap.js
+++ b/tests/versioned/instrumentation-unsupported.tap.js
@@ -29,7 +29,7 @@ tap.test('instrumentation is supported', (t) => {
   })
 
   t.test('AWS should not have newrelic attributes', (t) => {
-    t.assert(!AWS.__NR_instrumented, 'Found __NR_instrumented')
+    t.assert(!AWS.__NR_instrumented, '__NR_instrumented not present')
     t.end()
   })
 

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -17,7 +17,21 @@
         "aws-sdk.tap.js",
         "dynamodb.tap.js",
         "http-services.tap.js",
+        "instrumentation-supported.tap.js",
         "s3.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=8.0"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "versions": "2.2.48"
+        }
+      },
+      "files": [
+        "instrumentation-unsupported.tap.js"
       ]
     }
   ],


### PR DESCRIPTION
Re: https://github.com/newrelic/node-newrelic-aws-sdk/compare/astorm/fix-old-versions?expand=1

Implements a simple feature sniffer in instrumentation that looks for required object properties before attempting to apply instrumentation.  Should fix _Cannot read property '[foo]' of undefined_ of undefined errors.  

If this simple pilot works well we should consider expanding it to sniff features for each aws instrumentation and/or formalize something like this into the shimmer system.