### PR TITLE
DDB test cleanup

### DIFF
--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -2,6 +2,7 @@
 
 const EXTERN_PATTERN = /^External\/.*?amazonaws\.com/
 const SQS_PATTERN = /^MessageBroker\/SQS\/Queue/
+const DATASTORE_PATTERN = /^Datastore/
 const SEGMENT_DESTINATION = 0x20
 
 function checkAWSAttributes(t, segment, pattern, markedSegments = []) {
@@ -27,6 +28,7 @@ function checkAWSAttributes(t, segment, pattern, markedSegments = []) {
 module.exports = {
   EXTERN_PATTERN,
   SQS_PATTERN,
+  DATASTORE_PATTERN,
   SEGMENT_DESTINATION,
 
   checkAWSAttributes

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -160,13 +160,17 @@ tap.test('DynamoDB', (t) => {
 })
 
 function finish(t, tx) {
-  const segments = common.checkAWSAttributes(t, tx.trace.root, common.DATASTORE_PATTERN)
+  const root = tx.trace.root
+  const segments = common.checkAWSAttributes(t, root, common.DATASTORE_PATTERN)
 
   t.equal(
     segments.length,
     tests.length,
     `should have ${tests.length} aws datastore segments`
   )
+
+  const externalSegments = common.checkAWSAttributes(t, root, common.EXTERN_PATTERN)
+  t.equal(externalSegments.length, 0, 'should not have any External segments')
 
   segments.forEach((segment, i) => {
     const operation = tests[i].operation

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -160,7 +160,7 @@ tap.test('DynamoDB', (t) => {
 })
 
 function finish(t, tx) {
-  const segments = common.checkAWSAttributes(t, tx.trace.root, /^Datastore/)
+  const segments = common.checkAWSAttributes(t, tx.trace.root, common.DATASTORE_PATTERN)
 
   t.equal(
     segments.length,


### PR DESCRIPTION
* Adds external segment checking to ensure aren't capturing externals for instrumented datastore methods (callback style).
* Updates DynamoDB testing to leverage new dynamically generated table instead of needing a permanent one.