### PR TITLE
Resolve promise issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
     "browser": false
   },
   "parserOptions": {
-    "ecmaVersion": 8
+    "ecmaVersion": 6
   },
   "rules": {
     "brace-style": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
     "browser": false
   },
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 8
   },
   "rules": {
     "brace-style": "error",

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "rules": {
     "max-nested-callbacks": "off",
     "func-names": "off",

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -1,8 +1,10 @@
 'use strict'
 
-const EXTERN_PATTERN = /^External\/.*?amazonaws\.com/
-const SQS_PATTERN = /^MessageBroker\/SQS\/Queue/
 const DATASTORE_PATTERN = /^Datastore/
+const EXTERN_PATTERN = /^External\/.*?amazonaws\.com/
+const SNS_PATTERN = /^MessageBroker\/SNS\/Topic/
+const SQS_PATTERN = /^MessageBroker\/SQS\/Queue/
+
 const SEGMENT_DESTINATION = 0x20
 
 function checkAWSAttributes(t, segment, pattern, markedSegments = []) {
@@ -26,9 +28,11 @@ function checkAWSAttributes(t, segment, pattern, markedSegments = []) {
 }
 
 module.exports = {
-  EXTERN_PATTERN,
-  SQS_PATTERN,
   DATASTORE_PATTERN,
+  EXTERN_PATTERN,
+  SNS_PATTERN,
+  SQS_PATTERN,
+
   SEGMENT_DESTINATION,
 
   checkAWSAttributes

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -40,7 +40,7 @@ tap.test('DynamoDB', (t) => {
     const ddb = new AWS.DynamoDB({region: 'us-east-1'})
     const docClient = new AWS.DynamoDB.DocumentClient({region: 'us-east-1'})
 
-    tableName = `DELETE_aws-sdk-test-table-${Math.floor(Math.random() * 100000)}`
+    tableName = `delete-aws-sdk-test-table-${Math.floor(Math.random() * 100000)}`
     tests = createTests(ddb, docClient, tableName)
 
     done()

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -162,6 +162,7 @@ async function waitTableCreated(t, ddb, tableName, segment, started) {
     data = await ddb.describeTable({ TableName: tableName }).promise()
   } catch (err) {
     t.error(err)
+    return
   }
 
   if (data.Table.TableStatus === 'ACTIVE') {

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -208,17 +208,19 @@ function deleteTableIfNeeded(t, api, tableName, cb) {
 }
 
 /**
- * Manually sets segment.opaque to false.
+ * Manually sets segment.opaque to true.
  * Adds __NR_test_restoreOpaque to restore state.
  * @param {*} segment
  */
 function forceOpaqueSegment(segment) {
+  const originalOpaque = segment.opaque
+  // Our promise instrumentation will reset opaque status each call
+  // so we always need to set this.
+  segment.opaque = true
+
   if (segment.__NR_test_restoreOpaque != null) {
     return
   }
-
-  const originalOpaque = segment.opaque
-  segment.opaque = true
 
   segment.__NR_test_restoreOpaque = function restoreOpaque() {
     segment.opaque = originalOpaque

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -162,10 +162,9 @@ async function waitTableCreated(t, ddb, tableName, segment, started) {
     data = await ddb.describeTable({ TableName: tableName }).promise()
   } catch (err) {
     t.error(err)
-    return
   }
 
-  if (data.Table.TableStatus === 'ACTIVE') {
+  if (data && data.Table.TableStatus === 'ACTIVE') {
     segment.__NR_test_restoreOpaque()
 
     t.comment('Table is active.')

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -9,6 +9,19 @@
       },
       "dependencies": {
         "aws-sdk": {
+          "versions": "2.2.48"
+        }
+      },
+      "files": [
+        "instrumentation-unsupported.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=8.0"
+      },
+      "dependencies": {
+        "aws-sdk": {
           "versions": ">=2.380.0",
           "samples": 10
         }
@@ -19,19 +32,6 @@
         "http-services.tap.js",
         "instrumentation-supported.tap.js",
         "s3.tap.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": ">=8.0"
-      },
-      "dependencies": {
-        "aws-sdk": {
-          "versions": "2.2.48"
-        }
-      },
-      "files": [
-        "instrumentation-unsupported.tap.js"
       ]
     }
   ],

--- a/tests/versioned/s3.tap.js
+++ b/tests/versioned/s3.tap.js
@@ -28,8 +28,8 @@ tap.test('S3 buckets', (t) => {
     done()
   })
 
-  t.test('commands', (t) => {
-    const Bucket = 'aws-sdk-test-bucket-' + Math.floor(Math.random() * 100000)
+  t.test('commands with callbacks', (t) => {
+    const Bucket = 'delete-aws-sdk-test-bucket-' + Math.floor(Math.random() * 100000)
     t.tearDown(() => {
       // Ensure bucket gets deleted even if test goes awry.
       S3.deleteBucket({Bucket}, () => {})
@@ -48,24 +48,68 @@ tap.test('S3 buckets', (t) => {
               t.error(err)
             }
             tx.end()
-            setImmediate(finish, tx)
+
+            const args = [t, tx]
+            setImmediate(finish, ...args)
           })
         })
       })
     })
+  })
 
-    function finish(tx) {
-      const externals = common.checkAWSAttributes(t, tx.trace.root, common.EXTERN_PATTERN)
-      t.equal(externals.length, 3, 'should have 3 aws externals')
-      const [head, create, del] = externals
-      checkAttrs(t, head, 'headBucket')
-      checkAttrs(t, create, 'createBucket')
-      checkAttrs(t, del, 'deleteBucket')
+  t.test('commands with promises', (t) => {
+    const Bucket = 'delete-aws-sdk-test-bucket-' + Math.floor(Math.random() * 100000)
+    t.tearDown(() => {
+      // Ensure bucket gets deleted even if test goes awry.
+      S3.deleteBucket({Bucket}, () => {})
+    })
 
-      t.end()
-    }
+    helper.runInTransaction(async tx => {
+      const bucketParams = {Bucket}
+      let headBucketError = null
+      try {
+        await S3.headBucket(bucketParams).promise()
+      } catch (err) {
+        headBucketError = err
+      } finally {
+        t.matches(headBucketError, {code: 'NotFound'}, 'should get not found for bucket')
+      }
+
+      try {
+        const createData = await S3.createBucket(bucketParams).promise()
+        t.matches(createData, {Location: `/${Bucket}`}, 'should have matching location')
+      } catch (err) {
+        t.error(err)
+      }
+
+      try {
+        await S3.deleteBucket(bucketParams).promise()
+      } catch (err) {
+        // Sometimes S3 doesn't make the bucket quickly enough. The cleanup
+        // in `t.tearDown` should get it after we do all our checks.
+        if (err && err.code !== 'NoSuchBucket') {
+          t.error(err)
+        }
+      }
+
+      tx.end()
+
+      const args = [t, tx]
+      setImmediate(finish, ...args)
+    })
   })
 })
+
+function finish(t, tx) {
+  const externals = common.checkAWSAttributes(t, tx.trace.root, common.EXTERN_PATTERN)
+  t.equal(externals.length, 3, 'should have 3 aws externals')
+  const [head, create, del] = externals
+  checkAttrs(t, head, 'headBucket')
+  checkAttrs(t, create, 'createBucket')
+  checkAttrs(t, del, 'deleteBucket')
+
+  t.end()
+}
 
 function checkAttrs(t, segment, operation) {
   const attrs = segment.attributes.get(common.SEGMENT_DESTINATION)

--- a/tests/versioned/sns.tap.js
+++ b/tests/versioned/sns.tap.js
@@ -48,8 +48,13 @@ tap.test('SNS', (t) => {
     })
 
     function finish(tx) {
-      const messages = common.checkAWSAttributes(t, tx.trace.root, /^MessageBroker/)
+      const root = tx.trace.root
+
+      const messages = common.checkAWSAttributes(t, root, common.SNS_PATTERN)
       t.equal(messages.length, 1, 'should have 1 message broker segment')
+
+      const externalSegments = common.checkAWSAttributes(t, root, common.EXTERN_PATTERN)
+      t.equal(externalSegments.length, 0, 'should not have any External segments')
 
       const attrs = messages[0].attributes.get(common.SEGMENT_DESTINATION)
       t.matches(attrs, {

--- a/tests/versioned/sns.tap.js
+++ b/tests/versioned/sns.tap.js
@@ -4,7 +4,7 @@ const common = require('./common')
 const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 
-const TOPIC_NAME = `test-topic-${Math.floor(Math.random() * 100000)}`
+const TOPIC_NAME = `delete-aws-sdk-test-topic-${Math.floor(Math.random() * 100000)}`
 
 tap.test('SNS', (t) => {
   t.autoend()

--- a/tests/versioned/sqs.tap.js
+++ b/tests/versioned/sqs.tap.js
@@ -29,7 +29,7 @@ tap.test('SQS API', (t) => {
     AWS = require('aws-sdk')
     sqs = new AWS.SQS({apiVersion: '2012-11-05', region: AWS_REGION})
 
-    queueName = 'aws-sdk-test-queue-' + Math.floor(Math.random() * 100000)
+    queueName = 'delete-aws-sdk-test-queue-' + Math.floor(Math.random() * 100000)
 
     done()
   })

--- a/tests/versioned/sqs.tap.js
+++ b/tests/versioned/sqs.tap.js
@@ -13,6 +13,12 @@ tap.test('SQS API', (t) => {
   let AWS = null
   let sqs = null
 
+  let queueName = null
+  let queueUrl = null
+  let sendMessageRequestId = null
+  let sendMessageBatchRequestId = null
+  let receiveMessageRequestId = null
+
   t.beforeEach((done) => {
     helper = utils.TestAgent.makeInstrumented()
     helper.registerInstrumentation({
@@ -22,21 +28,32 @@ tap.test('SQS API', (t) => {
     })
     AWS = require('aws-sdk')
     sqs = new AWS.SQS({apiVersion: '2012-11-05', region: AWS_REGION})
+
+    queueName = 'aws-sdk-test-queue-' + Math.floor(Math.random() * 100000)
+
     done()
   })
 
   t.afterEach((done) => {
-    helper && helper.unload()
-    done()
+    deleteQueue(sqs, queueUrl, (err) => {
+      t.error(err)
+
+      helper && helper.unload()
+      helper = null
+      sqs = null
+      AWS = null
+
+      queueName = null
+      queueUrl = null
+      sendMessageRequestId = null
+      sendMessageBatchRequestId = null
+      receiveMessageRequestId = null
+
+      done()
+    })
   })
 
-  t.test('commands', (t) => {
-    const queueName = 'aws-sdk-test-queue-' + Math.floor(Math.random() * 100000)
-    let queueUrl = null
-    let sendMessageRequestId = null
-    let sendMessageBatchRequestId = null
-    let receiveMessageRequestId = null
-
+  t.test('commands with callback', (t) => {
     const createParams = getCreateParams(queueName)
     sqs.createQueue(createParams, function(createErr, createData) {
       t.error(createErr)
@@ -66,56 +83,103 @@ tap.test('SQS API', (t) => {
               receiveMessageRequestId = getRequestId(t, receiveData)
 
               transaction.end()
-              setImmediate(finish, transaction)
+
+              const args = [t, transaction]
+              setImmediate(finish, ...args)
             })
           })
         })
       })
     })
+  })
 
-    t.tearDown(() => {
-      // Cleanup queue after test
-      const deleteParams = {
-        QueueUrl: queueUrl
-      }
+  t.test('commands with promises', (t) => {
+    const createParams = getCreateParams(queueName)
+    sqs.createQueue(createParams, function(createErr, createData) {
+      t.error(createErr)
 
-      sqs.deleteQueue(deleteParams, function(err) {
-          if (err) {
-            throw err
-          }
+      queueUrl = createData.QueueUrl
+
+      helper.runInTransaction(async transaction => {
+        try {
+          const sendMessageParams = getSendMessageParams(queueUrl)
+          const sendData = await sqs.sendMessage(sendMessageParams).promise()
+          t.ok(sendData.MessageId)
+
+          sendMessageRequestId = getRequestId(t, sendData)
+        } catch (error) {
+          t.error(error)
+        }
+
+        try {
+          const sendMessageBatchParams = getSendMessageBatchParams(queueUrl)
+          const sendBatchData =
+            await sqs.sendMessageBatch(sendMessageBatchParams).promise()
+          t.ok(sendBatchData.Successful)
+
+          sendMessageBatchRequestId = getRequestId(t, sendBatchData)
+        } catch (error) {
+          t.error(error)
+        }
+
+        try {
+          const receiveMessageParams = getReceiveMessageParams(queueUrl)
+          const receiveData = await sqs.receiveMessage(receiveMessageParams).promise()
+          t.ok(receiveData.Messages)
+
+          receiveMessageRequestId = getRequestId(t, receiveData)
+        } catch (error) {
+          t.error(error)
+        }
+
+        transaction.end()
+
+        const args = [t, transaction]
+        setImmediate(finish, ...args)
       })
     })
-
-    function finish(transaction) {
-      const expectedSegmentCount = 3
-
-      const root = transaction.trace.root
-      const segments = common.checkAWSAttributes(t, root, common.SQS_PATTERN)
-
-      t.equal(
-        segments.length,
-        expectedSegmentCount,
-        `should have ${expectedSegmentCount} AWS MessageBroker/SQS segments`
-      )
-
-      const externalSegments = common.checkAWSAttributes(t, root, common.EXTERN_PATTERN)
-      t.equal(externalSegments.length, 0, 'should not have any External segments')
-
-      const [sendMessage, sendMessageBatch, receiveMessage] = segments
-
-      checkName(t, sendMessage.name, 'Produce', queueName)
-      checkAttributes(t, sendMessage, 'sendMessage', sendMessageRequestId)
-
-      checkName(t, sendMessageBatch.name, 'Produce', queueName)
-      checkAttributes(t, sendMessageBatch, 'sendMessageBatch', sendMessageBatchRequestId)
-
-      checkName(t, receiveMessage.name, 'Consume', queueName)
-      checkAttributes(t, receiveMessage, 'receiveMessage', receiveMessageRequestId)
-
-      t.end()
-    }
   })
+
+  function finish(t, transaction) {
+    const expectedSegmentCount = 3
+
+    const root = transaction.trace.root
+    const segments = common.checkAWSAttributes(t, root, common.SQS_PATTERN)
+
+    t.equal(
+      segments.length,
+      expectedSegmentCount,
+      `should have ${expectedSegmentCount} AWS MessageBroker/SQS segments`
+    )
+
+    const externalSegments = common.checkAWSAttributes(t, root, common.EXTERN_PATTERN)
+    t.equal(externalSegments.length, 0, 'should not have any External segments')
+
+    const [sendMessage, sendMessageBatch, receiveMessage] = segments
+
+    checkName(t, sendMessage.name, 'Produce', queueName)
+    checkAttributes(t, sendMessage, 'sendMessage', sendMessageRequestId)
+
+    checkName(t, sendMessageBatch.name, 'Produce', queueName)
+    checkAttributes(t, sendMessageBatch, 'sendMessageBatch', sendMessageBatchRequestId)
+
+    checkName(t, receiveMessage.name, 'Consume', queueName)
+    checkAttributes(t, receiveMessage, 'receiveMessage', receiveMessageRequestId)
+
+    t.end()
+  }
 })
+
+function deleteQueue(sqs, queueUrl, cb) {
+  // Cleanup queue after test
+  const deleteParams = {
+    QueueUrl: queueUrl
+  }
+
+  sqs.deleteQueue(deleteParams, function(err) {
+      cb(err)
+  })
+}
 
 function checkName(t, name, action, queueName) {
   const specificName = `/${action}/Named/${queueName}`

--- a/tests/versioned/sqs.tap.js
+++ b/tests/versioned/sqs.tap.js
@@ -98,6 +98,9 @@ tap.test('SQS API', (t) => {
         `should have ${expectedSegmentCount} AWS MessageBroker/SQS segments`
       )
 
+      const externalSegments = common.checkAWSAttributes(t, root, common.EXTERN_PATTERN)
+      t.equal(externalSegments.length, 0, 'should not have any External segments')
+
       const [sendMessage, sendMessageBatch, receiveMessage] = segments
 
       checkName(t, sendMessage.name, 'Produce', queueName)


### PR DESCRIPTION
* Adds official support for API promise calls. 
   For example: `await ddb.createTable(params).promise()`.
  * Fixed issue where external spans/segments would be incorrectly created in addition to more specific types such as datastore spans/segments. This also resulted in missing attributes from the more specific spans/segments.
  * Fixed issue where spans/segments would not have timing update appropriately upon promise resolution. These would show sub-millisecond execution time as the time captured was the execution of the initial function not accounting for async execution.
