### PR TITLE
Bumps DynamoDB tap.test timeout to avoid versioned test terminations

### DIFF
--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -6,11 +6,11 @@ const utils = require('@newrelic/test-utilities')
 const async = require('async')
 
 const RETRY_MS = 1500
-const RETRY_MAX_MS = 15500
+const RETRY_MAX_MS = 30000
 
 // NOTE: these take a while to run and can trigger tap CLI file timeout
 // This can be avoided via --no-timeout or --timeout=<value>
-tap.test('DynamoDB', {timeout: 60000}, (t) => {
+tap.test('DynamoDB', {timeout: 90000}, (t) => {
   t.autoend()
 
   let helper = null
@@ -173,7 +173,7 @@ async function waitTableCreated(t, ddb, tableName, segment, started) {
 
   const currentTime = Date.now()
   const startTime = started || currentTime
-  const elapsed = startTime - currentTime
+  const elapsed = currentTime - startTime
 
   if (elapsed > RETRY_MAX_MS) {
     segment.__NR_test_restoreOpaque()

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -10,7 +10,7 @@ const RETRY_MAX_MS = 15500
 
 // NOTE: these take a while to run and can trigger tap CLI file timeout
 // This can be avoided via --no-timeout or --timeout=<value>
-tap.test('DynamoDB', (t) => {
+tap.test('DynamoDB', {timeout: 60000}, (t) => {
   t.autoend()
 
   let helper = null


### PR DESCRIPTION
* Bumps DynamoDB `tap.test` timeout to avoid versioned test terminations when table creates are slow.

Didn't see this behavior prior but did see for the branches w/ the last release upon completion as well as when tried to roll new module into agent. Tested via `npm link` and seems to resolve locally, at least.

Unfortunately, because we run tests from the modules themselves, this will require another deploy.