### PR TITLE
NODE-2187 Fix crash with DAX client

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -35,8 +35,8 @@ function instrument(shim, AWS) {
         return {
           name: operationName,
           parameters: {
-            host: this.endpoint.host,
-            port_path_or_id: this.endpoint.port,
+            host: this.endpoint && this.endpoint.host,
+            port_path_or_id: this.endpoint && this.endpoint.port,
             collection: params && params.TableName || 'Unknown'
           },
           callback: shim.LAST,
@@ -58,11 +58,16 @@ function instrument(shim, AWS) {
       const params = args[0]
       const dynamoOperation = this.serviceClientOperationsMap[operationName]
 
+      // DocumentClient can be defined with a different service such as AmazonDaxClient.
+      // In these cases, an endpoint property may not exist. In the DAX case,
+      // the eventual cached endpoint to be hit is not known at this point.
+      const endpoint = this.service && this.service.endpoint
+
       return {
         name: dynamoOperation,
         parameters: {
-          host: this.service.endpoint.host,
-          port_path_or_id: this.service.endpoint.port,
+          host: endpoint && endpoint.host,
+          port_path_or_id: endpoint && endpoint.port,
           collection: params && params.TableName || 'Unknown'
         },
         callback: shim.LAST,

--- a/tests/versioned/amazon-dax-client.tap.js
+++ b/tests/versioned/amazon-dax-client.tap.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const tap = require('tap')
+const utils = require('@newrelic/test-utilities')
+const common = require('./common')
+
+// This will not resolve / allow web requests. Even with real ones, requests
+// have to execute within the same VPC as the DAX configuration. When adding DAX support,
+// we may be able to fake part of this via nock or similar.
+const DAX_ENDPOINTS = [
+  'this.is.not.real1.amazonaws.com:8111',
+  'this.is.not.real2.amazonaws.com:8111'
+]
+
+tap.test('amazon-dax-client', (t) => {
+  t.autoend()
+
+  let helper = null
+  let AWS = null
+  let daxClient = null
+  let docClient = null
+
+  t.beforeEach((done) => {
+    helper = utils.TestAgent.makeInstrumented()
+    helper.registerInstrumentation({
+      moduleName: 'aws-sdk',
+      type: 'conglomerate',
+      onRequire: require('../../lib/instrumentation')
+    })
+
+
+    AWS = require('aws-sdk')
+    const AmazonDaxClient = require('amazon-dax-client')
+
+    daxClient = new AmazonDaxClient({
+      endpoints: DAX_ENDPOINTS,
+      maxRetries: 0 // fail fast
+    })
+    docClient = new AWS.DynamoDB.DocumentClient({ service: daxClient })
+
+    done()
+  })
+
+  t.afterEach((done) => {
+    helper && helper.unload()
+
+    helper = null
+    AWS = null
+
+    done()
+  })
+
+  t.test('should not crash when using DAX', (t) => {
+    helper.runInTransaction(() => {
+      // We don't need a successful case to repro
+      const getParam = getDocItemParams('TableDoesNotExist', 'ArtistDoesNotExist')
+      docClient.get(getParam, (err) => {
+        t.ok(err)
+        t.end()
+      })
+    })
+  })
+
+  t.test('should capture instance data as unknown using DAX', (t) => {
+    helper.runInTransaction((transaction) => {
+      // We don't need a successful case to repro
+      const getParam = getDocItemParams('TableDoesNotExist', 'ArtistDoesNotExist')
+      docClient.get(getParam, (err) => {
+        t.ok(err)
+
+        const root = transaction.trace.root
+
+        // Won't have the attributes cause not making web request...
+        const segments = common.getSegments(t, root, common.DATASTORE_PATTERN)
+
+        t.equal(segments.length, 1)
+
+        const externalSegments = common.checkAWSAttributes(t, root, common.EXTERN_PATTERN)
+        t.equal(externalSegments.length, 0, 'should not have any External segments')
+
+        const segment = segments[0]
+        t.equal(segment.name, 'Datastore/operation/DynamoDB/getItem')
+
+        const attrs = segment.attributes.get(common.SEGMENT_DESTINATION)
+        t.matches(attrs, {
+          host: 'unknown',
+          port_path_or_id: 'unknown',
+          collection: 'TableDoesNotExist',
+          product: 'DynamoDB'
+        }, 'should have expected attributes')
+
+        t.end()
+      })
+    })
+  })
+})
+
+function getDocItemParams(tableName, uniqueArtist) {
+  const params = {
+    Key: {
+      Artist: uniqueArtist,
+      SongTitle: 'Call Me Today'
+    },
+    TableName: tableName
+  }
+
+  return params
+}

--- a/tests/versioned/amazon-dax-client.tap.js
+++ b/tests/versioned/amazon-dax-client.tap.js
@@ -46,6 +46,8 @@ tap.test('amazon-dax-client', (t) => {
 
     helper = null
     AWS = null
+    daxClient = null
+    docClient = null
 
     done()
   })
@@ -71,7 +73,7 @@ tap.test('amazon-dax-client', (t) => {
         const root = transaction.trace.root
 
         // Won't have the attributes cause not making web request...
-        const segments = common.getSegments(t, root, common.DATASTORE_PATTERN)
+        const segments = common.getMatchingSegments(t, root, common.DATASTORE_PATTERN)
 
         t.equal(segments.length, 1)
 

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -27,6 +27,18 @@ function checkAWSAttributes(t, segment, pattern, markedSegments = []) {
   return markedSegments
 }
 
+function getSegments(t, segment, pattern, markedSegments = []) {
+  if (pattern.test(segment.name)) {
+    markedSegments.push(segment)
+  }
+
+  segment.children.forEach((child) => {
+    getSegments(t, child, pattern, markedSegments)
+  })
+
+  return markedSegments
+}
+
 module.exports = {
   DATASTORE_PATTERN,
   EXTERN_PATTERN,
@@ -35,5 +47,6 @@ module.exports = {
 
   SEGMENT_DESTINATION,
 
-  checkAWSAttributes
+  checkAWSAttributes,
+  getSegments
 }

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -27,13 +27,13 @@ function checkAWSAttributes(t, segment, pattern, markedSegments = []) {
   return markedSegments
 }
 
-function getSegments(t, segment, pattern, markedSegments = []) {
+function getMatchingSegments(t, segment, pattern, markedSegments = []) {
   if (pattern.test(segment.name)) {
     markedSegments.push(segment)
   }
 
   segment.children.forEach((child) => {
-    getSegments(t, child, pattern, markedSegments)
+    getMatchingSegments(t, child, pattern, markedSegments)
   })
 
   return markedSegments
@@ -48,5 +48,5 @@ module.exports = {
   SEGMENT_DESTINATION,
 
   checkAWSAttributes,
-  getSegments
+  getMatchingSegments
 }

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -33,6 +33,21 @@
         "instrumentation-supported.tap.js",
         "s3.tap.js"
       ]
+    },
+    {
+      "engines": {
+        "node": ">=8.0"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "versions": ">=2.380.0",
+          "samples": 10
+        },
+        "amazon-dax-client": ">=1.0.2"
+      },
+      "files": [
+        "amazon-dax-client.tap.js"
+      ]
     }
   ],
   "dependencies": {}


### PR DESCRIPTION
* Fixed issue where instrumentation would crash pulling `host` and `port` values when `AmazonDaxClient` was used as the service for `DocumentClient.`

  `AmazonDaxClient` requests will report 'unknown' for `host` and `port` attributes. Other oddities may still exist until DAX officially supported.


------

See issue: https://github.com/newrelic/node-newrelic/issues/321