### PR TITLE
node-newrelic-357: Fix lastIndexOf Errors

### DIFF
--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const {grabLastUrlSegment} = require('./util')
 module.exports = {
   name: 'sqs',
   type: 'message',
@@ -40,9 +41,4 @@ function recordMessageApi(shim, original, name, args) {
   }
 }
 
-function grabLastUrlSegment(url) {
-  const lastSlashIndex = url.lastIndexOf('/')
-  const lastItem = url.substr(lastSlashIndex + 1)
 
-  return lastItem
-}

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,12 @@
+'use strict'
+function grabLastUrlSegment(url='/') {
+  url = '' + url  // cast as string
+  const lastSlashIndex = url.lastIndexOf('/')
+  const lastItem = url.substr(lastSlashIndex + 1)
+
+  return lastItem
+}
+
+module.exports = {
+  grabLastUrlSegment
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,8 @@
 'use strict'
 function grabLastUrlSegment(url = '/') {
-  url = '' + url  // cast as string
+  // cast URL as string, and an empty
+  // string for null, undefined, NaN etc.
+  url = '' + (url || '/')
   const lastSlashIndex = url.lastIndexOf('/')
   const lastItem = url.substr(lastSlashIndex + 1)
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,5 @@
 'use strict'
-function grabLastUrlSegment(url='/') {
+function grabLastUrlSegment(url = '/') {
   url = '' + url  // cast as string
   const lastSlashIndex = url.lastIndexOf('/')
   const lastItem = url.substr(lastSlashIndex + 1)

--- a/tests/unit/util.tap.js
+++ b/tests/unit/util.tap.js
@@ -11,7 +11,7 @@ tap.test('Utility Functions', (t) => {
     },
     {
       input: null,
-      output: 'null'
+      output: ''
     },
     {
       input: undefined,
@@ -19,7 +19,7 @@ tap.test('Utility Functions', (t) => {
     },
     {
       input: NaN,
-      output: 'NaN'
+      output: ''
     }
   ]
 

--- a/tests/unit/util.tap.js
+++ b/tests/unit/util.tap.js
@@ -20,7 +20,7 @@ tap.test('Utility Functions', (t) => {
     {
       input: NaN,
       output: 'NaN'
-    },
+    }
   ]
 
   for (const [, fixture] of fixtures.entries()) {

--- a/tests/unit/util.tap.js
+++ b/tests/unit/util.tap.js
@@ -1,0 +1,33 @@
+'use strict'
+const tap = require('tap')
+const {grabLastUrlSegment} = require('../../lib/util')
+tap.test('Utility Functions', (t) => {
+  t.ok(grabLastUrlSegment, 'imported function successfully')
+
+  const fixtures = [
+    {
+      input: '/foo/baz/bar',
+      output: 'bar'
+    },
+    {
+      input: null,
+      output: 'null'
+    },
+    {
+      input: undefined,
+      output: ''
+    },
+    {
+      input: NaN,
+      output: 'NaN'
+    },
+  ]
+
+  for (const [, fixture] of fixtures.entries()) {
+    const result = grabLastUrlSegment(fixture.input)
+    t.equals(
+      result, fixture.output, `expecting ${result} to equal ${fixture.output}`
+    )
+  }
+  t.end()
+})


### PR DESCRIPTION
This PR fixes a [customer reported error](https://github.com/newrelic/node-newrelic/issues/357) where the lack of a `QueueURL` parameter can cause a `TypeError: Cannot read property 'lastIndexOf' of undefined` error.   

It also moves the `grabLastUrlSegment` function into a utility library to allow for more straightforward unit testing of this method. 