### PR TITLE
Remove AWS servers as dependency for versioned tests

### DIFF
--- a/tests/versioned/amazon-dax-client.tap.js
+++ b/tests/versioned/amazon-dax-client.tap.js
@@ -6,7 +6,9 @@
 
 const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
+
 const common = require('./common')
+const { FAKE_CREDENTIALS } = require('./aws-server-stubs')
 
 // This will not resolve / allow web requests. Even with real ones, requests
 // have to execute within the same VPC as the DAX configuration. When adding DAX support,
@@ -37,6 +39,7 @@ tap.test('amazon-dax-client', (t) => {
     const AmazonDaxClient = require('amazon-dax-client')
 
     daxClient = new AmazonDaxClient({
+      credentials: FAKE_CREDENTIALS,
       endpoints: DAX_ENDPOINTS,
       maxRetries: 0 // fail fast
     })

--- a/tests/versioned/aws-sdk.tap.js
+++ b/tests/versioned/aws-sdk.tap.js
@@ -9,71 +9,93 @@ const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 utils.assert.extendTap(tap)
 
+const { createEmptyResponseServer } = require('./aws-server-stubs')
+
 tap.test('aws-sdk', (t) => {
   t.autoend()
 
   let helper = null
   let AWS = null
 
+  let server = null
+  let credentials = {
+    accessKeyId: 'test id',
+    secretAccessKey: 'test key'
+  }
+  let endpoint = null
+
   t.beforeEach((done) => {
-    helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../lib/instrumentation')
+    server = createEmptyResponseServer()
+    server.listen(0, () => {
+      helper = utils.TestAgent.makeInstrumented()
+      helper.registerInstrumentation({
+        moduleName: 'aws-sdk',
+        type: 'conglomerate',
+        onRequire: require('../../lib/instrumentation')
+      })
+      AWS = require('aws-sdk')
+      AWS.config.update({region: 'us-east-1'})
+
+      endpoint = `http://localhost:${server.address().port}`
+      done()
     })
-    AWS = require('aws-sdk')
-    done()
   })
 
   t.afterEach((done) => {
+    server.close()
+    server = null
+
     helper && helper.unload()
     AWS = null
     done()
   })
 
-  t.test('should mark requests to be dt-disabled', (t) => {
-    const https = require('https')
-    sinon.spy(https, 'request')
+  t.test('should mark requests to be dt-disabled', {skip: true}, (t) => {
+    // http because we've changed endpoint to be http
+    const http = require('http')
+    sinon.spy(http, 'request')
     t.tearDown(() => {
       // `afterEach` runs before `tearDown`, so the sinon spy may have already
       // been removed.
-      if (https.request.restore) {
-        https.request.restore()
+      if (http.request.restore) {
+        http.request.restore()
       }
-    })
-
-    AWS.config.update({
-      region: 'region',
-      credentials: new AWS.CognitoIdentityCredentials({
-        IdentityPoolId: 'foobar'
-      })
     })
 
     const s3 = new AWS.S3({
       apiVersion: '2006-03-01',
+      credentials: credentials,
+      endpoint: endpoint,
+      // allows using generic endpoint, instead of needing a
+      // bucket.endpoint server setup.
+      s3ForcePathStyle: true,
       params: {Bucket: 'bucket'}
     })
-    s3.listObjects({Delimiter: '/'}, () => {})
+    s3.listObjects({Delimiter: '/'}, (err) => {
+      t.error(err)
 
-    if (t.ok(https.request.calledOnce, 'should call http.request')) {
-      const args = https.request.getCall(0).args
-      const headers = args[0].headers
-      const symbols = Object.getOwnPropertySymbols(headers).filter((s) => {
-        return s.toString() === 'Symbol(Disable distributed tracing)'
-      })
-      t.equal(symbols.length, 1, 'should have disabled dt')
-    }
-    t.end()
+      if (t.ok(http.request.calledOnce, 'should call http.request')) {
+        const args = http.request.getCall(0).args
+        const headers = args[0].headers
+        const symbols = Object.getOwnPropertySymbols(headers).filter((s) => {
+          return s.toString() === 'Symbol(Disable distributed tracing)'
+        })
+        t.equal(symbols.length, 1, 'should have disabled dt')
+      }
+      t.end()
+    })
   })
 
   t.test('should maintain transaction state in promises', (t) => {
-    const service = new AWS.SES()
+    const service = new AWS.SES({
+      credentials: credentials,
+      endpoint: endpoint
+    })
     helper.runInTransaction((tx) => {
       service.cloneReceiptRuleSet({
         OriginalRuleSetName: 'RuleSetToClone',
         RuleSetName: 'RuleSetToCreate'
-      }).promise().catch(() => {
+      }).promise().then(() => {
         t.transaction(tx)
         tx.end()
         ender()
@@ -85,7 +107,7 @@ tap.test('aws-sdk', (t) => {
       service.cloneReceiptRuleSet({
         OriginalRuleSetName: 'RuleSetToClone',
         RuleSetName: 'RuleSetToCreate'
-      }).promise().catch(() => {
+      }).promise().then(() => {
         t.transaction(tx)
         tx.end()
         ender()

--- a/tests/versioned/aws-sdk.tap.js
+++ b/tests/versioned/aws-sdk.tap.js
@@ -9,7 +9,7 @@ const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 utils.assert.extendTap(tap)
 
-const { createEmptyResponseServer } = require('./aws-server-stubs')
+const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('./aws-server-stubs')
 
 tap.test('aws-sdk', (t) => {
   t.autoend()
@@ -18,10 +18,6 @@ tap.test('aws-sdk', (t) => {
   let AWS = null
 
   let server = null
-  let credentials = {
-    accessKeyId: 'test id',
-    secretAccessKey: 'test key'
-  }
   let endpoint = null
 
   t.beforeEach((done) => {
@@ -64,7 +60,7 @@ tap.test('aws-sdk', (t) => {
 
     const s3 = new AWS.S3({
       apiVersion: '2006-03-01',
-      credentials: credentials,
+      credentials: FAKE_CREDENTIALS,
       endpoint: endpoint,
       // allows using generic endpoint, instead of needing a
       // bucket.endpoint server setup.
@@ -88,7 +84,7 @@ tap.test('aws-sdk', (t) => {
 
   t.test('should maintain transaction state in promises', (t) => {
     const service = new AWS.SES({
-      credentials: credentials,
+      credentials: FAKE_CREDENTIALS,
       endpoint: endpoint
     })
     helper.runInTransaction((tx) => {

--- a/tests/versioned/aws-server-stubs/dynamodb-server/index.js
+++ b/tests/versioned/aws-server-stubs/dynamodb-server/index.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const http = require('http')
+
+function createDynamoDbServer() {
+  const server = http.createServer(function(req, res) {
+    if (req.method === 'POST') {
+      handleDdbPost(req, res)
+      return
+    }
+
+    res.statusCode = 500
+    res.end()
+  })
+
+  return server
+}
+
+function handleDdbPost(req, res) {
+  let body = ''
+
+  req.on('data', chunk => {
+      body += chunk.toString()
+  })
+
+  req.on('end', () => {
+    // we have to read the body for things to work,
+    // so might as well log it out for troubleshooting.
+    // eslint-disable-next-line no-console
+    console.log(body)
+
+    // currently, the tests do not rely on real responses back.
+    // it is enough to return something valid to the client
+    res.end()
+  })
+}
+
+module.exports = createDynamoDbServer

--- a/tests/versioned/aws-server-stubs/empty-response-server/index.js
+++ b/tests/versioned/aws-server-stubs/empty-response-server/index.js
@@ -1,3 +1,7 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
 'use strict'
 
 const http = require('http')

--- a/tests/versioned/aws-server-stubs/empty-response-server/index.js
+++ b/tests/versioned/aws-server-stubs/empty-response-server/index.js
@@ -2,10 +2,10 @@
 
 const http = require('http')
 
-function createDynamoDbServer() {
+function createEmptyResponseServer() {
   const server = http.createServer(function(req, res) {
     if (req.method === 'POST') {
-      handleDdbPost(req, res)
+      handlePost(req, res)
       return
     }
 
@@ -16,7 +16,7 @@ function createDynamoDbServer() {
   return server
 }
 
-function handleDdbPost(req, res) {
+function handlePost(req, res) {
   let body = ''
 
   req.on('data', chunk => {
@@ -29,10 +29,10 @@ function handleDdbPost(req, res) {
     // eslint-disable-next-line no-console
     console.log(body)
 
-    // currently, the tests do not rely on real responses back.
-    // it is enough to return something valid to the client
+    // currently, some tests do not rely on real responses back.
+    // it is enough to return something valid to the client.
     res.end()
   })
 }
 
-module.exports = createDynamoDbServer
+module.exports = createEmptyResponseServer

--- a/tests/versioned/aws-server-stubs/empty-response-server/index.js
+++ b/tests/versioned/aws-server-stubs/empty-response-server/index.js
@@ -4,31 +4,32 @@ const http = require('http')
 
 function createEmptyResponseServer() {
   const server = http.createServer(function(req, res) {
-    if (req.method === 'POST') {
+    if (
+      req.method === 'POST' ||
+      req.method === 'PUT' ||
+      req.method === 'HEAD' ||
+      req.method === 'DELETE'
+    ) {
       handlePost(req, res)
       return
     }
 
+    // sometimes the aws-sdk will obfuscate this error
+    // so logging out.
+    // eslint-disable-next-line no-console
+    console.log('Unhandled request method')
+
     res.statusCode = 500
-    res.end()
+    res.end('Unhandled request method')
   })
 
   return server
 }
 
 function handlePost(req, res) {
-  let body = ''
-
-  req.on('data', chunk => {
-      body += chunk.toString()
-  })
+  req.on('data', () => {})
 
   req.on('end', () => {
-    // we have to read the body for things to work,
-    // so might as well log it out for troubleshooting.
-    // eslint-disable-next-line no-console
-    console.log(body)
-
     // currently, some tests do not rely on real responses back.
     // it is enough to return something valid to the client.
     res.end()

--- a/tests/versioned/aws-server-stubs/empty-response-server/index.js
+++ b/tests/versioned/aws-server-stubs/empty-response-server/index.js
@@ -5,6 +5,7 @@ const http = require('http')
 function createEmptyResponseServer() {
   const server = http.createServer(function(req, res) {
     if (
+      req.method === 'GET' ||
       req.method === 'POST' ||
       req.method === 'PUT' ||
       req.method === 'HEAD' ||
@@ -17,7 +18,7 @@ function createEmptyResponseServer() {
     // sometimes the aws-sdk will obfuscate this error
     // so logging out.
     // eslint-disable-next-line no-console
-    console.log('Unhandled request method')
+    console.log('Unhandled request method: ', req.method)
 
     res.statusCode = 500
     res.end('Unhandled request method')

--- a/tests/versioned/aws-server-stubs/index.js
+++ b/tests/versioned/aws-server-stubs/index.js
@@ -3,7 +3,15 @@
 const createSqsServer = require('./sqs-server')
 const createEmptyResponseServer = require('./empty-response-server')
 
+// Specific values are unimportant because we'll be hitting our
+// custom servers. But they need to be populated.
+const FAKE_CREDENTIALS = {
+  accessKeyId: 'FAKE ID',
+  secretAccessKey: 'FAKE KEY'
+}
+
 module.exports = {
   createSqsServer,
-  createEmptyResponseServer
+  createEmptyResponseServer,
+  FAKE_CREDENTIALS
 }

--- a/tests/versioned/aws-server-stubs/index.js
+++ b/tests/versioned/aws-server-stubs/index.js
@@ -1,3 +1,7 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
 'use strict'
 
 const createSqsServer = require('./sqs-server')

--- a/tests/versioned/aws-server-stubs/index.js
+++ b/tests/versioned/aws-server-stubs/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const createSqsServer = require('./sqs-server')
+const createDynamoDbServer = require('./dynamodb-server')
 
 module.exports = {
-  createSqsServer
+  createSqsServer,
+  createDynamoDbServer
 }
-
-

--- a/tests/versioned/aws-server-stubs/index.js
+++ b/tests/versioned/aws-server-stubs/index.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const createSqsServer = require('./sqs-server')
+
+module.exports = {
+  createSqsServer
+}
+
+

--- a/tests/versioned/aws-server-stubs/index.js
+++ b/tests/versioned/aws-server-stubs/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const createSqsServer = require('./sqs-server')
-const createDynamoDbServer = require('./dynamodb-server')
+const createEmptyResponseServer = require('./empty-response-server')
 
 module.exports = {
   createSqsServer,
-  createDynamoDbServer
+  createEmptyResponseServer
 }

--- a/tests/versioned/aws-server-stubs/sqs-server/index.js
+++ b/tests/versioned/aws-server-stubs/sqs-server/index.js
@@ -1,3 +1,7 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
 'use strict'
 
 const http = require('http')

--- a/tests/versioned/aws-server-stubs/sqs-server/index.js
+++ b/tests/versioned/aws-server-stubs/sqs-server/index.js
@@ -103,7 +103,7 @@ function getCreateQueueResponse(endpoint, queueName, callback) {
 }
 
 function replaceQueueUrl(xml, endpoint, queueName) {
-  const modifiedResponse = createQueueResponse.replace(
+  const modifiedResponse = xml.replace(
     '<QueueUrl></QueueUrl>',
     `<QueueUrl>${endpoint}/queue/${queueName}</QueueUrl>`
   )

--- a/tests/versioned/aws-server-stubs/sqs-server/index.js
+++ b/tests/versioned/aws-server-stubs/sqs-server/index.js
@@ -1,0 +1,177 @@
+'use strict'
+
+const http = require('http')
+const fs = require('fs')
+const path = require('path')
+
+function createSqsServer() {
+  const server = http.createServer(function(req, res) {
+    if (req.method === 'POST') {
+      handleSqsPost(req, res)
+      return
+    }
+
+    res.statusCode = 500
+    res.end()
+  })
+
+  return server
+}
+
+function handleSqsPost(req, res) {
+  let body = ''
+
+  req.on('data', chunk => {
+      body += chunk.toString()
+  })
+
+  req.on('end', () => {
+    const endpoint = `http://localhost:${req.connection.localPort}`
+    const parsed = parseBody(body)
+
+    const getDataFunction = createGetDataFromAction(endpoint, parsed)
+
+    getDataFunction((err, data) => {
+      if (err) {
+        res.statusCode = 500
+        // eslint-disable-next-line no-console
+        console.log(err)
+      }
+
+      res.end(data)
+    })
+  })
+}
+
+function createGetDataFromAction(endpoint, body) {
+  switch (body.Action) {
+    case 'CreateQueue':
+      return getCreateQueueResponse.bind(null, endpoint, body.QueueName)
+    case 'SendMessage':
+      return getSendMessageResponse.bind(null)
+    case 'SendMessageBatch':
+      return getSendMessageBatchResponse.bind(null)
+    case 'ReceiveMessage':
+      return getReceiveMessageResponse.bind(null)
+    default:
+      return function actionNotImplemented(callback) {
+        setImmediate(() => {
+          callback(new Error('Action not implemented'))
+        })
+      }
+  }
+}
+
+function parseBody(body) {
+  const parsed = Object.create(null)
+
+  const items = body.split('&')
+  items.forEach((item) => {
+    const [key, value] = item.split('=')
+    parsed[key] = value
+  })
+
+  return parsed
+}
+
+let createQueueResponse = null
+function getCreateQueueResponse(endpoint, queueName, callback) {
+  if (createQueueResponse) {
+    const modifiedResponse = replaceQueueUrl(createQueueResponse, endpoint, queueName)
+
+    setImmediate(() => {
+      callback(null, modifiedResponse)
+    })
+    return
+  }
+
+  readFromXml('create-queue-response.xml', (err, data) => {
+    if (err) {
+      callback(err)
+      return
+    }
+
+    createQueueResponse = data
+    const modifiedResponse = replaceQueueUrl(createQueueResponse, endpoint, queueName)
+
+    callback(null, modifiedResponse)
+  })
+}
+
+function replaceQueueUrl(xml, endpoint, queueName) {
+  const modifiedResponse = createQueueResponse.replace(
+    '<QueueUrl></QueueUrl>',
+    `<QueueUrl>${endpoint}/queue/${queueName}</QueueUrl>`
+  )
+
+  return modifiedResponse
+}
+
+let sendMessageResponse = null
+function getSendMessageResponse(callback) {
+  if (sendMessageResponse) {
+    setImmediate(() => {
+      callback(null, sendMessageResponse)
+    })
+    return
+  }
+
+  readFromXml('send-message-response.xml', (err, data) => {
+    if (err) {
+      callback(err)
+      return
+    }
+
+    sendMessageResponse = data
+    callback(null, sendMessageResponse)
+  })
+}
+
+let sendMessageBatchResponse = null
+function getSendMessageBatchResponse(callback) {
+  if (sendMessageBatchResponse) {
+    setImmediate(() => {
+      callback(null, sendMessageBatchResponse)
+    })
+    return
+  }
+
+  readFromXml('send-message-batch-response.xml', (err, data) => {
+    if (err) {
+      callback(err)
+      return
+    }
+
+    sendMessageBatchResponse = data
+    callback(null, sendMessageBatchResponse)
+  })
+}
+
+let receiveMessageResponse = null
+function getReceiveMessageResponse(callback) {
+  if (receiveMessageResponse) {
+    setImmediate(() => {
+      callback(null, receiveMessageResponse)
+    })
+    return
+  }
+
+  readFromXml('receive-message-response.xml', (err, data) => {
+    if (err) {
+      callback(err)
+      return
+    }
+
+    receiveMessageResponse = data
+    callback(null, receiveMessageResponse)
+  })
+}
+
+function readFromXml(fileName, callback) {
+  const fullPath = path.join(__dirname, 'responses', fileName)
+  fs.readFile(fullPath, 'utf8', function(err, data) {
+    callback(err, data)
+  })
+}
+
+module.exports = createSqsServer

--- a/tests/versioned/aws-server-stubs/sqs-server/responses/create-queue-response.xml
+++ b/tests/versioned/aws-server-stubs/sqs-server/responses/create-queue-response.xml
@@ -1,0 +1,8 @@
+<CreateQueueResponse>
+  <CreateQueueResult>
+      <QueueUrl></QueueUrl>
+  </CreateQueueResult>
+  <ResponseMetadata>
+      <RequestId>cb919c0a-9bce-4afe-9b48-9bdf2412bb67</RequestId>
+  </ResponseMetadata>
+</CreateQueueResponse>

--- a/tests/versioned/aws-server-stubs/sqs-server/responses/receive-message-response.xml
+++ b/tests/versioned/aws-server-stubs/sqs-server/responses/receive-message-response.xml
@@ -1,0 +1,33 @@
+<ReceiveMessageResponse>
+  <ReceiveMessageResult>
+    <Message>
+      <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+      <ReceiptHandle>
+        MbZj6wDWliJvwwJaBV3dcjk2YW2vA3STFFljTM8tJJg6HRG6PYSasuWXPJBCw
+        Lj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQQE
+        auMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0=
+      </ReceiptHandle>
+      <MD5OfBody>fafb00f5732ab283681e124bf8747ed1</MD5OfBody>
+      <Body>This is a test message</Body>
+      <Attribute>
+        <Name>SenderId</Name>
+        <Value>195004372649</Value>
+      </Attribute>
+      <Attribute>
+        <Name>SentTimestamp</Name>
+        <Value>1238099229000</Value>
+      </Attribute>
+      <Attribute>
+        <Name>ApproximateReceiveCount</Name>
+        <Value>2</Value>
+      </Attribute>
+      <Attribute>
+        <Name>ApproximateFirstReceiveTimestamp</Name>
+        <Value>1595887234772</Value>
+      </Attribute>
+    </Message>
+  </ReceiveMessageResult>
+  <ResponseMetadata>
+    <RequestId>b6633655-283d-45b4-aee4-4e84e0ae6afa</RequestId>
+  </ResponseMetadata>
+</ReceiveMessageResponse>

--- a/tests/versioned/aws-server-stubs/sqs-server/responses/send-message-batch-response.xml
+++ b/tests/versioned/aws-server-stubs/sqs-server/responses/send-message-batch-response.xml
@@ -1,0 +1,17 @@
+<SendMessageBatchResponse>
+  <SendMessageBatchResult>
+    <SendMessageBatchResultEntry>
+        <Id>ONE</Id>
+        <MessageId>0a5231c7-8bff-4955-be2e-8dc7c50a25fa</MessageId>
+        <MD5OfMessageBody>8b2f30468657cfc118bbbebb6ad52b5a</MD5OfMessageBody>
+    </SendMessageBatchResultEntry>
+    <SendMessageBatchResultEntry>
+        <Id>TWO</Id>
+        <MessageId>15ee1ed3-87e7-40c1-bdaa-2e49968ea7e9</MessageId>
+        <MD5OfMessageBody>446e666e0c0a8695b7a9693c082bc5da</MD5OfMessageBody>
+    </SendMessageBatchResultEntry>
+  </SendMessageBatchResult>
+  <ResponseMetadata>
+    <RequestId>ca1ad5d0-8271-408b-8d0f-1351bf547e74</RequestId>
+  </ResponseMetadata>
+</SendMessageBatchResponse>

--- a/tests/versioned/aws-server-stubs/sqs-server/responses/send-message-response.xml
+++ b/tests/versioned/aws-server-stubs/sqs-server/responses/send-message-response.xml
@@ -1,0 +1,9 @@
+<SendMessageResponse>
+  <SendMessageResult>
+    <MD5OfMessageBody>fafb00f5732ab283681e124bf8747ed1</MD5OfMessageBody>
+    <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+  </SendMessageResult>
+  <ResponseMetadata>
+      <RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId>
+  </ResponseMetadata>
+</SendMessageResponse>

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const DATASTORE_PATTERN = /^Datastore/
-const EXTERN_PATTERN = /^External\/.*?amazonaws\.com/
+const EXTERN_PATTERN = /^External\/.*/
 const SNS_PATTERN = /^MessageBroker\/SNS\/Topic/
 const SQS_PATTERN = /^MessageBroker\/SQS\/Queue/
 

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -9,7 +9,7 @@ const utils = require('@newrelic/test-utilities')
 const async = require('async')
 
 const common = require('./common')
-const { createEmptyResponseServer } = require('./aws-server-stubs')
+const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('./aws-server-stubs')
 
 tap.test('DynamoDB', (t) => {
   t.autoend()
@@ -33,18 +33,15 @@ tap.test('DynamoDB', (t) => {
       })
 
       AWS = require('aws-sdk')
-      const creds = {
-        accessKeyId: 'test id',
-        secretAccessKey: 'test key'
-      }
+
       const endpoint = `http://localhost:${server.address().port}`
       const ddb = new AWS.DynamoDB({
-        credentials: creds,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint,
         region: 'us-east-1'
       })
       const docClient = new AWS.DynamoDB.DocumentClient({
-        credentials: creds,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint,
         region: 'us-east-1'
       })

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -4,65 +4,70 @@
 */
 'use strict'
 
-const common = require('./common')
 const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 const async = require('async')
 
-const RETRY_MS = 1500
-const RETRY_MAX_MS = 30000
+const common = require('./common')
+const { createDynamoDbServer } = require('./aws-server-stubs')
 
-// NOTE: these take a while to run and can trigger tap CLI file timeout
-// This can be avoided via --no-timeout or --timeout=<value>
-tap.test('DynamoDB', {timeout: 90000}, (t) => {
+tap.test('DynamoDB', (t) => {
   t.autoend()
 
   let helper = null
   let AWS = null
-  let notInstrumentedDdb = null
 
   let tableName = null
   let tests = null
 
+  let server = null
+
   t.beforeEach((done) => {
-    // For administrative tasks we don't want to impact metrics or risk breaking
-    const notInstrumentedAws = require('aws-sdk')
-    notInstrumentedDdb = new notInstrumentedAws.DynamoDB({region: 'us-east-1'})
+    server = createDynamoDbServer()
+    server.listen(0, () => {
+      helper = utils.TestAgent.makeInstrumented()
+      helper.registerInstrumentation({
+        moduleName: 'aws-sdk',
+        type: 'conglomerate',
+        onRequire: require('../../lib/instrumentation')
+      })
 
-    // Cleanup require cache so instrumentation will work afterwards.
-    const awsPath = require.resolve('aws-sdk')
-    delete require.cache[awsPath]
+      AWS = require('aws-sdk')
+      const creds = {
+        accessKeyId: 'test id',
+        secretAccessKey: 'test key'
+      }
+      const endpoint = `http://localhost:${server.address().port}`
+      const ddb = new AWS.DynamoDB({
+        credentials: creds,
+        endpoint: endpoint,
+        region: 'us-east-1'
+      })
+      const docClient = new AWS.DynamoDB.DocumentClient({
+        credentials: creds,
+        endpoint: endpoint,
+        region: 'us-east-1'
+      })
 
-    helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../lib/instrumentation')
-    })
-
-    AWS = require('aws-sdk')
-    const ddb = new AWS.DynamoDB({region: 'us-east-1'})
-    const docClient = new AWS.DynamoDB.DocumentClient({region: 'us-east-1'})
-
-    tableName = `delete-aws-sdk-test-table-${Math.floor(Math.random() * 100000)}`
-    tests = createTests(ddb, docClient, tableName)
-
-    done()
-  })
-
-  t.afterEach((done) => {
-    deleteTableIfNeeded(t, notInstrumentedDdb, tableName, () => {
-      helper && helper.unload()
-
-      helper = null
-
-      notInstrumentedDdb = null
-      AWS = null
-      tests = null
-      tableName = null
+      tableName = `delete-aws-sdk-test-table-${Math.floor(Math.random() * 100000)}`
+      tests = createTests(ddb, docClient, tableName)
 
       done()
     })
+  })
+
+  t.afterEach((done) => {
+    server.close()
+    server = null
+
+    helper && helper.unload()
+    helper = null
+
+    AWS = null
+    tests = null
+    tableName = null
+
+    done()
   })
 
   t.test('commands with callback', (t) => {
@@ -71,15 +76,6 @@ tap.test('DynamoDB', {timeout: 90000}, (t) => {
         t.comment(`Testing ${cfg.method}`)
         cfg.api[cfg.method](cfg.params, (err) => {
           t.error(err)
-
-          if (cfg.method === 'createTable') {
-            const segment = helper.agent.tracer.getSegment()
-
-            return waitTableCreated(t, notInstrumentedDdb, tableName, segment)
-              .then(() => {
-                setImmediate(cb)
-              })
-          }
 
           return setImmediate(cb)
         })
@@ -103,11 +99,6 @@ tap.test('DynamoDB', {timeout: 90000}, (t) => {
 
         try {
           await cfg.api[cfg.method](cfg.params).promise()
-
-          if (cfg.method === 'createTable') {
-            const segment = helper.agent.tracer.getSegment()
-            await waitTableCreated(t, notInstrumentedDdb, tableName, segment)
-          }
         } catch (err) {
           t.error(err)
         }
@@ -155,81 +146,6 @@ function finish(t, tests, tx) {
   })
 
   t.end()
-}
-
-async function waitTableCreated(t, ddb, tableName, segment, started) {
-  // A hack to avoid this showing via outbound http instrumentation.
-  forceOpaqueSegment(segment)
-
-  let data = null
-  try {
-    data = await ddb.describeTable({ TableName: tableName }).promise()
-  } catch (err) {
-    t.error(err)
-  }
-
-  if (data && data.Table.TableStatus === 'ACTIVE') {
-    segment.__NR_test_restoreOpaque()
-
-    t.comment('Table is active.')
-    return
-  }
-
-  const currentTime = Date.now()
-  const startTime = started || currentTime
-  const elapsed = currentTime - startTime
-
-  if (elapsed > RETRY_MAX_MS) {
-    segment.__NR_test_restoreOpaque()
-
-    t.ok(false, `Should not take longer than ${RETRY_MAX_MS}ms for table create.`)
-    return
-  }
-
-  t.comment(`Table does not yet exist, scheduling ${RETRY_MS}ms out.`)
-  await delay(RETRY_MS)
-  await waitTableCreated(t, ddb, tableName, segment, startTime)
-}
-
-function deleteTableIfNeeded(t, api, tableName, cb) {
-  api.describeTable({ TableName: tableName }, (err, data) => {
-    const tableExists = !(err && err.code === 'ResourceNotFoundException')
-
-    if (!tableExists || (data && data.Table.TableStatus === 'DELETING')) {
-      // table deleted or in process of deleting, all is good.
-      return setImmediate(cb)
-    }
-
-    t.error(err)
-
-    t.comment('Attempting to manually delete table')
-    const deleteTableParams = getDeleteTableParams(tableName)
-    return api.deleteTable(deleteTableParams, (err) => {
-      t.error(err)
-      cb()
-    })
-  })
-}
-
-/**
- * Manually sets segment.opaque to true.
- * Adds __NR_test_restoreOpaque to restore state.
- * @param {*} segment
- */
-function forceOpaqueSegment(segment) {
-  const originalOpaque = segment.opaque
-  // Our promise instrumentation will reset opaque status each call
-  // so we always need to set this.
-  segment.opaque = true
-
-  if (segment.__NR_test_restoreOpaque != null) {
-    return
-  }
-
-  segment.__NR_test_restoreOpaque = function restoreOpaque() {
-    segment.opaque = originalOpaque
-    delete segment.__NR_test_restoreOpaque
-  }
 }
 
 function createTests(ddb, docClient, tableName) {
@@ -367,10 +283,4 @@ function getDocQueryParams(tableName, uniqueArtist) {
   }
 
   return params
-}
-
-function delay(delayms) {
-  return new Promise(function(resolve) {
-    setTimeout(resolve, delayms)
-  })
 }

--- a/tests/versioned/dynamodb.tap.js
+++ b/tests/versioned/dynamodb.tap.js
@@ -9,7 +9,7 @@ const utils = require('@newrelic/test-utilities')
 const async = require('async')
 
 const common = require('./common')
-const { createDynamoDbServer } = require('./aws-server-stubs')
+const { createEmptyResponseServer } = require('./aws-server-stubs')
 
 tap.test('DynamoDB', (t) => {
   t.autoend()
@@ -23,7 +23,7 @@ tap.test('DynamoDB', (t) => {
   let server = null
 
   t.beforeEach((done) => {
-    server = createDynamoDbServer()
+    server = createEmptyResponseServer()
     server.listen(0, () => {
       helper = utils.TestAgent.makeInstrumented()
       helper.registerInstrumentation({

--- a/tests/versioned/http-services.tap.js
+++ b/tests/versioned/http-services.tap.js
@@ -8,7 +8,7 @@ const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 
 const common = require('./common')
-const { createEmptyResponseServer } = require('./aws-server-stubs')
+const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('./aws-server-stubs')
 
 tap.test('AWS HTTP Services', (t) => {
   t.autoend()
@@ -17,10 +17,6 @@ tap.test('AWS HTTP Services', (t) => {
   let AWS = null
 
   let server = null
-  let credentials = {
-    accessKeyId: 'test id',
-    secretAccessKey: 'test key'
-  }
   let endpoint = null
 
   t.beforeEach((done) => {
@@ -51,7 +47,7 @@ tap.test('AWS HTTP Services', (t) => {
   t.test('APIGateway', (t) => {
     helper.runInTransaction((tx) => {
       const service = new AWS.APIGateway({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint
       })
       service.createApiKey({
@@ -77,7 +73,7 @@ tap.test('AWS HTTP Services', (t) => {
   t.test('ELB', (t) => {
     helper.runInTransaction((tx) => {
       const service = new AWS.ELB({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint
       })
       service.addTags({
@@ -101,7 +97,7 @@ tap.test('AWS HTTP Services', (t) => {
   t.test('ElastiCache', (t) => {
     helper.runInTransaction((tx) => {
       const service = new AWS.ElastiCache({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint
       })
       service.addTagsToResource({
@@ -122,7 +118,7 @@ tap.test('AWS HTTP Services', (t) => {
   t.test('Lambda', (t) => {
     helper.runInTransaction((tx) => {
       const service = new AWS.Lambda({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint
       })
       service.addLayerVersionPermission({
@@ -143,7 +139,7 @@ tap.test('AWS HTTP Services', (t) => {
   t.test('RDS', (t) => {
     helper.runInTransaction((tx) => {
       const service = new AWS.RDS({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint
       })
       service.addRoleToDBCluster({
@@ -159,7 +155,7 @@ tap.test('AWS HTTP Services', (t) => {
   t.test('Redshift', (t) => {
     helper.runInTransaction((tx) => {
       const service = new AWS.Redshift({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint
       })
       service.acceptReservedNodeExchange({
@@ -175,7 +171,7 @@ tap.test('AWS HTTP Services', (t) => {
   t.test('Rekognition', (t) => {
     helper.runInTransaction((tx) => {
       const service = new AWS.Rekognition({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint
       })
       service.compareFaces({
@@ -202,7 +198,7 @@ tap.test('AWS HTTP Services', (t) => {
   t.test('SES', (t) => {
     helper.runInTransaction((tx) => {
       const service = new AWS.SES({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint
       })
       service.cloneReceiptRuleSet({

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -31,7 +31,9 @@
         "dynamodb.tap.js",
         "http-services.tap.js",
         "instrumentation-supported.tap.js",
-        "s3.tap.js"
+        "s3.tap.js",
+        "sqs.tap.js",
+        "sns.tap.js"
       ]
     },
     {

--- a/tests/versioned/s3.tap.js
+++ b/tests/versioned/s3.tap.js
@@ -8,7 +8,7 @@ const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 
 const common = require('./common')
-const { createEmptyResponseServer } = require('./aws-server-stubs')
+const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('./aws-server-stubs')
 
 tap.test('S3 buckets', (t) => {
   t.autoend()
@@ -18,10 +18,6 @@ tap.test('S3 buckets', (t) => {
   let S3 = null
 
   let server = null
-  let credentials = {
-    accessKeyId: 'test id',
-    secretAccessKey: 'test key'
-  }
 
   t.beforeEach((done) => {
     server = createEmptyResponseServer()
@@ -34,7 +30,7 @@ tap.test('S3 buckets', (t) => {
       })
       AWS = require('aws-sdk')
       S3 = new AWS.S3({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: `http://localhost:${server.address().port}`,
         // allows using generic endpoint, instead of needing a
         // bucket.endpoint server setup.

--- a/tests/versioned/sns.tap.js
+++ b/tests/versioned/sns.tap.js
@@ -8,7 +8,7 @@ const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 
 const common = require('./common')
-const { createEmptyResponseServer } = require('./aws-server-stubs')
+const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('./aws-server-stubs')
 
 tap.test('SNS', (t) => {
   t.autoend()
@@ -30,12 +30,9 @@ tap.test('SNS', (t) => {
         onRequire: require('../../lib/instrumentation')
       })
       AWS = require('aws-sdk')
-      const credentials = {
-        accessKeyId: 'test id',
-        secretAccessKey: 'test key'
-      }
+
       sns = new AWS.SNS({
-        credentials: credentials,
+        credentials: FAKE_CREDENTIALS,
         endpoint: `http://localhost:${server.address().port}`,
         region: 'us-east-1'
       })

--- a/tests/versioned/sqs.tap.js
+++ b/tests/versioned/sqs.tap.js
@@ -4,9 +4,11 @@
 */
 'use strict'
 
-const common = require('./common')
 const tap = require('tap')
+const { createSqsServer } = require('./aws-server-stubs')
 const utils = require('@newrelic/test-utilities')
+
+const common = require('./common')
 
 const AWS_REGION = 'us-east-1'
 
@@ -23,38 +25,54 @@ tap.test('SQS API', (t) => {
   let sendMessageBatchRequestId = null
   let receiveMessageRequestId = null
 
+  let server = null
+
   t.beforeEach((done) => {
-    helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../lib/instrumentation')
-    })
-    AWS = require('aws-sdk')
-    sqs = new AWS.SQS({apiVersion: '2012-11-05', region: AWS_REGION})
+    server = createSqsServer()
+    server.listen(0, () => {
+      helper = utils.TestAgent.makeInstrumented()
+      helper.registerInstrumentation({
+        moduleName: 'aws-sdk',
+        type: 'conglomerate',
+        onRequire: require('../../lib/instrumentation')
+      })
 
-    queueName = 'delete-aws-sdk-test-queue-' + Math.floor(Math.random() * 100000)
+      AWS = require('aws-sdk')
+      const creds = {
+        accessKeyId: 'test id',
+        secretAccessKey: 'test key'
+      }
+      const endpoint = `http://localhost:${server.address().port}`
+      sqs = new AWS.SQS({
+        credentials: creds,
+        endpoint: endpoint,
+        apiVersion: '2012-11-05',
+        region: AWS_REGION
+      })
 
-    done()
-  })
-
-  t.afterEach((done) => {
-    deleteQueue(sqs, queueUrl, (err) => {
-      t.error(err)
-
-      helper && helper.unload()
-      helper = null
-      sqs = null
-      AWS = null
-
-      queueName = null
-      queueUrl = null
-      sendMessageRequestId = null
-      sendMessageBatchRequestId = null
-      receiveMessageRequestId = null
+      queueName = 'delete-aws-sdk-test-queue-' + Math.floor(Math.random() * 100000)
 
       done()
     })
+  })
+
+  t.afterEach((done) => {
+    helper && helper.unload()
+
+    server.close()
+    server = null
+
+    helper = null
+    sqs = null
+    AWS = null
+
+    queueName = null
+    queueUrl = null
+    sendMessageRequestId = null
+    sendMessageBatchRequestId = null
+    receiveMessageRequestId = null
+
+    done()
   })
 
   t.test('commands with callback', (t) => {
@@ -173,17 +191,6 @@ tap.test('SQS API', (t) => {
     t.end()
   }
 })
-
-function deleteQueue(sqs, queueUrl, cb) {
-  // Cleanup queue after test
-  const deleteParams = {
-    QueueUrl: queueUrl
-  }
-
-  sqs.deleteQueue(deleteParams, function(err) {
-      cb(err)
-  })
-}
 
 function checkName(t, name, action, queueName) {
   const specificName = `/${action}/Named/${queueName}`

--- a/tests/versioned/sqs.tap.js
+++ b/tests/versioned/sqs.tap.js
@@ -8,7 +8,7 @@ const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 
 const common = require('./common')
-const { createSqsServer } = require('./aws-server-stubs')
+const { createSqsServer, FAKE_CREDENTIALS } = require('./aws-server-stubs')
 
 const AWS_REGION = 'us-east-1'
 
@@ -38,13 +38,10 @@ tap.test('SQS API', (t) => {
       })
 
       AWS = require('aws-sdk')
-      const creds = {
-        accessKeyId: 'test id',
-        secretAccessKey: 'test key'
-      }
+
       const endpoint = `http://localhost:${server.address().port}`
       sqs = new AWS.SQS({
-        credentials: creds,
+        credentials: FAKE_CREDENTIALS,
         endpoint: endpoint,
         apiVersion: '2012-11-05',
         region: AWS_REGION

--- a/tests/versioned/sqs.tap.js
+++ b/tests/versioned/sqs.tap.js
@@ -5,10 +5,10 @@
 'use strict'
 
 const tap = require('tap')
-const { createSqsServer } = require('./aws-server-stubs')
 const utils = require('@newrelic/test-utilities')
 
 const common = require('./common')
+const { createSqsServer } = require('./aws-server-stubs')
 
 const AWS_REGION = 'us-east-1'
 


### PR DESCRIPTION
* Removed AWS servers as dependency for versioned tests.
  
  Enables versioned test to run successfully for forked repo PRs.

Part 1 of 2 for: https://github.com/newrelic/node-newrelic-aws-sdk/issues/42

This makes it so we'll be able to run versioned tests on forked PR's in CI system. After this is landed, will be able to setup GitHub actions CI.

The most popular frameworks/libraries used for testing all didn't seem to work for one reason or another. Which was very sad. They either mocked too early (didn't hit our service instrumentation) or were inconsistent with returns (SQS). On the plus side, our needs were actually pretty limited based on what we were testing.

Current solution: custom http servers to mimic AWS servers. Most use a very generic server that returns empty success responses. SQS actually validates some specific data, so that is more stubbed out with example responses.

## Pros
* Tests run much faster. Slowest part is version installs. Runs in ~4min
* Still validating same explicit concepts in tests.
* Everyone running same tests.
* No additional $$ on test runs / failure to cleanup.
* No secret management needed.
* No complicated framework/setup.

## Cons
* Manual solution / we maintain it.
* Won't catch issues where we might break data sent that only shows up on server.
* Additional tested concepts may required additional functionality added to stub servers.
