### PR TITLE
upgraded test utils to run a file

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -459,7 +459,7 @@ This product includes source derived from [@newrelic/newrelic-oss-cli](https://g
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v5.1.0](https://github.com/newrelic/node-test-utilities/tree/v5.1.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v5.1.0/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.1.1](https://github.com/newrelic/node-test-utilities/tree/v6.1.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.1.1/LICENSE):
 
 ```
                                  Apache License

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@newrelic/eslint-config": "^0.0.2",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
-        "@newrelic/test-utilities": "^5.1.0",
+        "@newrelic/test-utilities": "^6.1.1",
         "async": "^2.6.1",
         "aws-sdk": "^2.403.0",
         "eslint": "^7.32.0",
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/@newrelic/test-utilities": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-5.1.0.tgz",
-      "integrity": "sha512-Z4W27G/ivPIVKA42liIQhnicuqA2Tqw62gkE2/tb92yZpZlyVLswqOovfM7/3vG3GuXJJ/mnceVMJYIC1MzRmw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.1.1.tgz",
+      "integrity": "sha512-JTOIqL0ybf1nTpqO5i5JQGdyEp6iXpUwx6YnaO7IKTxbJnnKYOrxaXyq0cRQXeGVv7TxcOXjhOVAO+eJB4C3cw==",
       "dev": true,
       "dependencies": {
         "async": "^2.6.0",
@@ -784,7 +784,7 @@
         "versioned-tests": "bin/version-manager.js"
       },
       "engines": {
-        "node": ">=10.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -10554,9 +10554,9 @@
       "requires": {}
     },
     "@newrelic/test-utilities": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-5.1.0.tgz",
-      "integrity": "sha512-Z4W27G/ivPIVKA42liIQhnicuqA2Tqw62gkE2/tb92yZpZlyVLswqOovfM7/3vG3GuXJJ/mnceVMJYIC1MzRmw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.1.1.tgz",
+      "integrity": "sha512-JTOIqL0ybf1nTpqO5i5JQGdyEp6iXpUwx6YnaO7IKTxbJnnKYOrxaXyq0cRQXeGVv7TxcOXjhOVAO+eJB4C3cw==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "third-party-updates": "oss third-party manifest && oss third-party notices && git add THIRD_PARTY_NOTICES.md third_party_manifest.json",
     "unit": "tap tests/unit/**/*.tap.js",
     "versioned": "npm run versioned:npm7",
-    "versioned:npm6": "versioned-tests --minor -i 2 'tests/versioned/**/*.tap.js'",
-    "versioned:npm7": "versioned-tests --minor --all -i 2 'tests/versioned/**/*.tap.js'",
+    "versioned:npm6": "versioned-tests --minor -i 2 tests/versioned/**/*.tap.js",
+    "versioned:npm7": "versioned-tests --minor --all -i 2 tests/versioned/**/*.tap.js",
     "lint": "eslint *.js lib tests",
     "lint:fix": "eslint --fix *.js lib tests",
     "prepare": "husky install"
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@newrelic/eslint-config": "^0.0.2",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
-    "@newrelic/test-utilities": "^5.1.0",
+    "@newrelic/test-utilities": "^6.1.1",
     "async": "^2.6.1",
     "aws-sdk": "^2.403.0",
     "eslint": "^7.32.0",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Nov 05 2021 14:53:14 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Thu Nov 18 2021 12:58:46 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic AWS-SDK Instrumentation",
   "projectUrl": "https://github.com/newrelic/node-newrelic-aws-sdk",
   "includeOptDeps": false,
@@ -31,15 +31,15 @@
       "licenseTextSource": "file",
       "publisher": "New Relic"
     },
-    "@newrelic/test-utilities@5.1.0": {
+    "@newrelic/test-utilities@6.1.1": {
       "name": "@newrelic/test-utilities",
-      "version": "5.1.0",
-      "range": "^5.1.0",
+      "version": "6.1.1",
+      "range": "^6.1.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v5.1.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.1.1",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v5.1.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.1.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Upgraded `@newrelic/test-utilities` to enable running 1 file through versioned runner

## Details
I had needs to just run 1 file so it can be achieved by now running

```sh
npx versioned-tests --minor --all -i 2 tests/versioned/aws-sdk-v3/<file>.tap.js
```
