### PR TITLE
added instrumentation for the lib-dynamodb document client.  

### DIFF
--- a/lib/v3-dynamodb-doc-client.js
+++ b/lib/v3-dynamodb-doc-client.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const DDB_COMMAND_TYPES = [
+  'PutItemCommand',
+  'GetItemCommand',
+  'UpdateItemCommand',
+  'DeleteItemCommand',
+  'BatchGetItemCommand',
+  'BatchWriteItemCommand',
+  'TransactGetItemsCommand',
+  'TransactWriteItemsCommand',
+  'QueryCommand',
+  'ScanCommand'
+]
+
+module.exports = function instrument(shim, name, resolvedName) {
+  const fileNameIndex = resolvedName.indexOf('/index')
+  const relativeFolder = resolvedName.substr(0, fileNameIndex)
+
+  // The path changes depending on the version... so we don't want to hard-code the relative
+  // path from the module root.
+  const ddbDocClientExport = shim.require(`${relativeFolder}/DynamoDBDocumentClient`)
+
+  if (!shim.isFunction(ddbDocClientExport.DynamoDBDocumentClient)) {
+    shim.logger.debug('Could not find DynamoDBDocumentClient, not instrumenting.')
+  }
+
+  shim.setDatastore(shim.DYNAMODB)
+  shim.wrapReturn(
+    ddbDocClientExport,
+    'DynamoDBDocumentClient',
+    function wrappedReturn(shim, fn, name, instance) {
+      postClientConstructor.call(instance, shim)
+    }
+  )
+  shim.wrapReturn(
+    ddbDocClientExport.DynamoDBDocumentClient,
+    'from',
+    function wrappedReturn(shim, fn, name, instance) {
+      postClientConstructor.call(instance, shim)
+    }
+  )
+}
+
+/**
+ * Calls the instances middlewareStack.use to register
+ * a plugin that adds a middleware to record the dynamo
+ * operations
+ * see: https://aws.amazon.com/blogs/developer/middleware-stack-modular-aws-sdk-js/
+ *
+ * @param {Shim} shim
+ */
+function postClientConstructor(shim) {
+  this.middlewareStack.use(getPlugin(shim, this.config))
+}
+
+/**
+ * Returns the plugin object that adds an initialize middleware
+ *
+ * @param {Shim} shim
+ * @param {Object} config DynamoDBDocumentClient config
+ */
+function getPlugin(shim, config) {
+  return {
+    applyToStack: (clientStack) => {
+      clientStack.add(ddbMiddleware.bind(null, shim, config), {
+        name: 'NewRelicDynamoDocClientMiddleware',
+        step: 'initialize',
+        priority: 'high'
+      })
+    }
+  }
+}
+
+/**
+ * Creates middleware that executes a wrapped middleware
+ * to record the dynamo operations when they are applicable
+ *
+ * @param {Shim} shim
+ * @param {Object} config DynamoDBDocumentClient config
+ * @param {function} next middleware function
+ * @param {Object} context command context
+ * @returns {function}
+ */
+function ddbMiddleware(shim, config, next, context) {
+  return async function wrappedMiddleware(args) {
+    if (!DDB_COMMAND_TYPES.includes(context.commandName)) {
+      return await next(args)
+    }
+
+    const endpoint = await config.endpoint()
+    const wrappedNext = shim.recordOperation(
+      next,
+      function wrapNext(shim, original, name, nextArgs) {
+        const [{ input: params }] = nextArgs
+        return {
+          name: context.commandName,
+          parameters: {
+            host: endpoint && endpoint.hostname,
+            port_path_or_id: endpoint && endpoint.port,
+            collection: (params && params.TableName) || 'Unknown'
+          },
+          callback: shim.LAST,
+          promise: true,
+          opaque: true
+        }
+      }
+    )
+
+    return await wrappedNext(args)
+  }
+}

--- a/lib/v3-dynamodb-doc-client.js
+++ b/lib/v3-dynamodb-doc-client.js
@@ -34,14 +34,14 @@ module.exports = function instrument(shim, name, resolvedName) {
   shim.wrapReturn(
     ddbDocClientExport,
     'DynamoDBDocumentClient',
-    function wrappedReturn(shim, fn, name, instance) {
+    function wrappedReturn(shim, fn, fnName, instance) {
       postClientConstructor.call(instance, shim)
     }
   )
   shim.wrapReturn(
     ddbDocClientExport.DynamoDBDocumentClient,
     'from',
-    function wrappedReturn(shim, fn, name, instance) {
+    function wrappedReturn(shim, fn, fnName, instance) {
       postClientConstructor.call(instance, shim)
     }
   )

--- a/nr-hooks.js
+++ b/nr-hooks.js
@@ -20,5 +20,10 @@ module.exports = [
     type: 'generic',
     moduleName: '@aws-sdk/smithy-client',
     onResolved: require('./lib/smithy-client')
+  },
+  {
+    type: 'datastore',
+    moduleName: '@aws-sdk/lib-dynamodb',
+    onResolved: require('./lib/v3-dynamodb-doc-client')
   }
 ]

--- a/tests/versioned/aws-sdk-v3/dynamo-doc-client.tap.js
+++ b/tests/versioned/aws-sdk-v3/dynamo-doc-client.tap.js
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const utils = require('@newrelic/test-utilities')
+const common = require('../common')
+const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('../aws-server-stubs')
+
+tap.test('DynamoDB', (t) => {
+  t.autoend()
+
+  let helper = null
+  let ddbCommands = null
+  let DynamoDBDocumentClient = null
+
+  let tableName = null
+  let tests = null
+  let client = null
+
+  let server = null
+
+  t.beforeEach(async () => {
+    server = createEmptyResponseServer()
+
+    await new Promise((resolve) => {
+      server.listen(0, resolve)
+    })
+
+    helper = utils.TestAgent.makeInstrumented()
+    common.registerCoreInstrumentation(helper)
+    helper.registerInstrumentation({
+      moduleName: '@aws-sdk/lib-dynamodb',
+      type: 'datastore',
+      onResolved: require('../../../lib/v3-dynamodb-doc-client')
+    })
+
+    const lib = require('@aws-sdk/lib-dynamodb')
+    DynamoDBDocumentClient = lib.DynamoDBDocumentClient
+    const { DynamoDBClient } = require('@aws-sdk/client-dynamodb')
+    ddbCommands = {
+      PutCommand: lib.PutCommand,
+      GetCommand: lib.GetCommand,
+      UpdateCommand: lib.UpdateCommand,
+      DeleteCommand: lib.DeleteCommand,
+      QueryCommand: lib.QueryCommand,
+      ScanCommand: lib.ScanCommand
+    }
+
+    const endpoint = `http://localhost:${server.address().port}`
+    client = new DynamoDBClient({
+      credentials: FAKE_CREDENTIALS,
+      endpoint: endpoint,
+      region: 'us-east-1'
+    })
+
+    tableName = `delete-aws-sdk-test-table-${Math.floor(Math.random() * 100000)}`
+    tests = createTests(tableName)
+  })
+
+  t.afterEach(() => {
+    server.destroy()
+    server = null
+
+    helper && helper.unload()
+    helper = null
+
+    tests = null
+    tableName = null
+    client = null
+    DynamoDBDocumentClient = null
+    Object.keys(require.cache).forEach((key) => {
+      if (
+        key.includes('@aws-sdk/lib-dynamodb') ||
+        key.includes('@aws-sdk/client-dynamodb') ||
+        key.includes('@aws-sdk/smithy-client')
+      ) {
+        delete require.cache[key]
+      }
+    })
+  })
+
+  t.test('client commands', (t) => {
+    const docClient = new DynamoDBDocumentClient(client)
+    helper.runInTransaction(async function (tx) {
+      // Execute commands in order
+      // Await works because this is in a for-loop / no callback api
+      for (let i = 0; i < tests.length; i++) {
+        const cfg = tests[i]
+        t.comment(`Testing ${cfg.operation}`)
+
+        try {
+          await docClient.send(new ddbCommands[cfg.command](cfg.params))
+        } catch (err) {
+          t.error(err)
+        }
+      }
+
+      tx.end()
+
+      const args = [t, tests, tx]
+      setImmediate(finish, ...args)
+    })
+  })
+
+  t.test('client from commands', (t) => {
+    const docClientFrom = DynamoDBDocumentClient.from(client)
+    helper.runInTransaction(async function (tx) {
+      // Execute commands in order
+      // Await works because this is in a for-loop / no callback api
+      for (let i = 0; i < tests.length; i++) {
+        const cfg = tests[i]
+        t.comment(`Testing ${cfg.operation}`)
+
+        try {
+          await docClientFrom.send(new ddbCommands[cfg.command](cfg.params))
+        } catch (err) {
+          t.error(err)
+        }
+      }
+
+      tx.end()
+
+      const args = [t, tests, tx]
+      setImmediate(finish, ...args)
+    })
+  })
+})
+
+function finish(t, tests, tx) {
+  const root = tx.trace.root
+  const segments = common.checkAWSAttributes(t, root, common.DATASTORE_PATTERN)
+
+  t.equal(segments.length, tests.length, `should have ${tests.length} aws datastore segments`)
+
+  const externalSegments = common.checkAWSAttributes(t, root, common.EXTERN_PATTERN)
+  t.equal(externalSegments.length, 0, 'should not have any External segments')
+
+  segments.forEach((segment, i) => {
+    const operation = tests[i].operation
+    t.equal(
+      segment.name,
+      `Datastore/operation/DynamoDB/${operation}`,
+      'should have operation in segment name'
+    )
+    const attrs = segment.attributes.get(common.SEGMENT_DESTINATION)
+    t.match(
+      attrs,
+      {
+        'host': String,
+        'port_path_or_id': String,
+        'product': 'DynamoDB',
+        'collection': String,
+        'aws.operation': operation,
+        'aws.requestId': String,
+        'aws.region': 'us-east-1',
+        'aws.service': 'DynamoDB'
+      },
+      'should have expected attributes'
+    )
+  })
+
+  t.end()
+}
+
+function createTests(tableName) {
+  const docUniqueArtist = `DELETE_One You Know ${Math.floor(Math.random() * 100000)}`
+  const docPutParams = getDocPutItemParams(tableName, docUniqueArtist)
+  const docItemParams = getDocItemParams(tableName, docUniqueArtist)
+  const docQueryParams = getDocQueryParams(tableName, docUniqueArtist)
+
+  const composedTests = [
+    { params: docPutParams, operation: 'PutItemCommand', command: 'PutCommand' },
+    { params: docItemParams, operation: 'GetItemCommand', command: 'GetCommand' },
+    { params: docItemParams, operation: 'UpdateItemCommand', command: 'UpdateCommand' },
+    { params: { TableName: tableName }, operation: 'ScanCommand', command: 'ScanCommand' },
+    { params: docQueryParams, operation: 'QueryCommand', command: 'QueryCommand' },
+    { params: docItemParams, operation: 'DeleteItemCommand', command: 'DeleteCommand' }
+  ]
+
+  return composedTests
+}
+
+function getDocPutItemParams(tableName, uniqueArtist) {
+  const params = {
+    Item: {
+      AlbumTitle: 'Somewhat Famous',
+      Artist: uniqueArtist,
+      SongTitle: 'Call Me Today'
+    },
+    TableName: tableName
+  }
+
+  return params
+}
+
+function getDocItemParams(tableName, uniqueArtist) {
+  const params = {
+    Key: {
+      Artist: uniqueArtist,
+      SongTitle: 'Call Me Today'
+    },
+    TableName: tableName
+  }
+
+  return params
+}
+
+function getDocQueryParams(tableName, uniqueArtist) {
+  const params = {
+    ExpressionAttributeValues: {
+      ':v1': uniqueArtist
+    },
+    KeyConditionExpression: 'Artist = :v1',
+    TableName: tableName
+  }
+
+  return params
+}

--- a/tests/versioned/aws-sdk-v3/package.json
+++ b/tests/versioned/aws-sdk-v3/package.json
@@ -151,6 +151,7 @@
         "node": ">=12.0"
       },
       "dependencies": {
+        "@aws-sdk/util-dynamodb": "latest",
         "@aws-sdk/client-dynamodb": "latest",
         "@aws-sdk/lib-dynamodb": {
           "versions": ">=3.0.0",

--- a/tests/versioned/aws-sdk-v3/package.json
+++ b/tests/versioned/aws-sdk-v3/package.json
@@ -145,6 +145,21 @@
       "files": [
         "sns.tap.js"
       ]
+    },
+    {
+      "engines": {
+        "node": ">=12.0"
+      },
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "latest",
+        "@aws-sdk/lib-dynamodb": {
+          "versions": ">=3.0.0",
+          "samples": 10
+        }
+      },
+      "files": [
+        "dynamo-doc-client.tap.js"
+      ]
     }
   ],
   "dependencies": {}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added instrumentation to support DynamoDB Document Client(`@aws-sdk/lib-dynamodb`)

## Links
Closes #101 

## Details
This code might be able to go away once we see how all the instrumentation works with #108.  To use the document client you have to pass in client.  I haven't tested yet but the document client may still record operations implicitly with the client.
