### PR TITLE
added semver check on agent for v3 instrumentation

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -14,6 +14,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 
 **[dependencies](#dependencies)**
 
+* [semver](#semver)
 
 **[devDependencies](#devDependencies)**
 
@@ -36,6 +37,29 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 
 
 ## dependencies
+
+### semver
+
+This product includes source derived from [semver](https://github.com/npm/node-semver) ([v7.3.5](https://github.com/npm/node-semver/tree/v7.3.5)), distributed under the [ISC License](https://github.com/npm/node-semver/blob/v7.3.5/LICENSE):
+
+```
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+```
 
 
 ## devDependencies
@@ -1097,7 +1121,7 @@ SOFTWARE.
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v8.6.0](https://github.com/newrelic/node-newrelic/tree/v8.6.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v8.6.0/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v8.7.0](https://github.com/newrelic/node-newrelic/tree/v8.7.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v8.7.0/LICENSE):
 
 ```
                                  Apache License

--- a/index.js
+++ b/index.js
@@ -11,7 +11,23 @@
  * then the supportability metrics for custom instrumentation will trigger.
  */
 const newrelic = require('newrelic')
+const semver = require('semver')
+const agentVersion = newrelic && newrelic.agent && newrelic.agent.version
 newrelic.instrumentConglomerate('aws-sdk', require('./lib/v2/instrumentation'))
+
+// TODO: Remove this semver check and semver module when we ship Node 18 support
+// A bug existed in 8.6.0 when we introduced the `onResolved` hook.
+// See: https://github.com/newrelic/node-newrelic/pull/986
+// To avoid unnecessary support issues we will require agent version >= 8.7.0 to
+// register AWS SDK v3 instrumentation
+if (!semver.satisfies(agentVersion, '>=8.7.0')) {
+  newrelic.shim.logger.warn(
+    'The New Relic Node.js agent must be >= 8.7.0 to instrument AWS SDK v3, current version: %s',
+    agentVersion
+  )
+  return
+}
+
 newrelic.instrument({
   moduleName: '@aws-sdk/smithy-client',
   onResolved: require('./lib/v3/smithy-client')

--- a/nr-hooks.js
+++ b/nr-hooks.js
@@ -4,36 +4,56 @@
  */
 
 'use strict'
+const newrelic = require('newrelic')
+const semver = require('semver')
+const agentVersion = newrelic && newrelic.agent && newrelic.agent.version
 
-module.exports = [
+const instrumentations = [
   {
     type: 'conglomerate',
     moduleName: 'aws-sdk',
     onRequire: require('./lib/v2/instrumentation')
-  },
-  {
-    type: 'generic',
-    moduleName: '@aws-sdk/smithy-client',
-    onResolved: require('./lib/v3/smithy-client')
-  },
-  {
-    type: 'message',
-    moduleName: '@aws-sdk/client-sns',
-    onResolved: require('./lib/v3/sns')
-  },
-  {
-    type: 'message',
-    moduleName: '@aws-sdk/client-sqs',
-    onResolved: require('./lib/v3/sqs')
-  },
-  {
-    type: 'datastore',
-    moduleName: '@aws-sdk/client-dynamodb',
-    onResolved: require('./lib/v3/client-dynamodb')
-  },
-  {
-    type: 'datastore',
-    moduleName: '@aws-sdk/lib-dynamodb',
-    onResolved: require('./lib/v3/lib-dynamodb')
   }
 ]
+
+// TODO: Remove this semver check and semver module when we ship Node 18 support
+// A bug existed in 8.6.0 when we introduced the `onResolved` hook.
+// See: https://github.com/newrelic/node-newrelic/pull/986
+// To avoid unnecessary support issues we will require agent version >= 8.7.0 to
+// register AWS SDK v3 instrumentation
+if (semver.satisfies(agentVersion, '>=8.7.0')) {
+  instrumentations.push(
+    {
+      type: 'generic',
+      moduleName: '@aws-sdk/smithy-client',
+      onResolved: require('./lib/v3/smithy-client')
+    },
+    {
+      type: 'message',
+      moduleName: '@aws-sdk/client-sns',
+      onResolved: require('./lib/v3/sns')
+    },
+    {
+      type: 'message',
+      moduleName: '@aws-sdk/client-sqs',
+      onResolved: require('./lib/v3/sqs')
+    },
+    {
+      type: 'datastore',
+      moduleName: '@aws-sdk/client-dynamodb',
+      onResolved: require('./lib/v3/client-dynamodb')
+    },
+    {
+      type: 'datastore',
+      moduleName: '@aws-sdk/lib-dynamodb',
+      onResolved: require('./lib/v3/lib-dynamodb')
+    }
+  )
+} else {
+  newrelic.shim.logger.warn(
+    'The New Relic Node.js agent must be >= 8.7.0 to instrument AWS SDK v3, current version: %s',
+    agentVersion
+  )
+}
+
+module.exports = instrumentations

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@newrelic/aws-sdk",
       "version": "4.0.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "devDependencies": {
         "@newrelic/eslint-config": "^0.0.2",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
@@ -21,7 +24,7 @@
         "eslint-plugin-prettier": "^3.4.0",
         "husky": "^7.0.2",
         "lint-staged": "^11.1.2",
-        "newrelic": "^8.6.0",
+        "newrelic": "^8.7.0",
         "prettier": "^2.3.2",
         "sinon": "^7.2.3",
         "tap": "^15.0.9"
@@ -640,6 +643,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/@newrelic/native-metrics/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/@newrelic/newrelic-oss-cli": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@newrelic/newrelic-oss-cli/-/newrelic-oss-cli-0.1.2.tgz",
@@ -785,6 +798,15 @@
       },
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/@newrelic/test-utilities/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1055,21 +1077,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@oclif/command/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@oclif/command/node_modules/widest-line": {
@@ -1486,21 +1493,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@oclif/plugin-commands/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/plugin-commands/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -1907,21 +1899,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@oclif/plugin-plugins/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/plugin-plugins/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2126,21 +2103,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@oclif/plugin-update/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/plugin-update/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2284,6 +2246,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@oclif/plugin-warn-if-update-available/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/@oclif/plugin-warn-if-update-available/node_modules/supports-color": {
@@ -3223,6 +3194,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/cli-ux/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/cli-ux/node_modules/strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -3888,21 +3868,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -5308,6 +5273,15 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/license-checker/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/license-checker/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5700,7 +5674,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5876,9 +5849,9 @@
       }
     },
     "node_modules/newrelic": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.6.0.tgz",
-      "integrity": "sha512-eCVrrccxkgLubAw/ovt20Yn1bcmPEs5t7w1UwKmgJISggkmS/CDjgmoHQen2cspb6ZI7AvM94dncupYbU1QLHw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.7.0.tgz",
+      "integrity": "sha512-lGTgfLvipr6QDum4f7P2BjwC3Cx9t7mvZVam/iQga/nd1723nz3fNGNnE/6Sceoye6PgXiSkLIeVOzvYGduz7w==",
       "dev": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.2.11",
@@ -5938,6 +5911,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/newrelic/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/nice-try": {
@@ -6009,6 +5991,15 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/normalize-path": {
@@ -6341,6 +6332,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/password-prompt/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/password-prompt/node_modules/shebang-command": {
@@ -6679,6 +6679,15 @@
         "graceful-fs": "^4.1.2"
       }
     },
+    "node_modules/read-installed/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/read-package-json": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
@@ -6939,12 +6948,17 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -9897,8 +9911,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -10453,6 +10466,15 @@
       "requires": {
         "nan": "^2.14.2",
         "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "@newrelic/newrelic-oss-cli": {
@@ -10567,6 +10589,14 @@
         "lodash": "^4.17.5",
         "log-update": "^1.0.2",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -10784,15 +10814,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         },
         "widest-line": {
           "version": "3.1.0",
@@ -11131,15 +11152,6 @@
           "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
           "dev": true
         },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -11463,15 +11475,6 @@
             }
           }
         },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -11634,15 +11637,6 @@
             }
           }
         },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -11754,6 +11748,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "supports-color": {
@@ -12500,6 +12500,12 @@
           "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
           "dev": true
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -12918,17 +12924,6 @@
         "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "eslint-config-prettier": {
@@ -14091,6 +14086,12 @@
             "minimist": "^1.2.5"
           }
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -14400,7 +14401,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -14533,9 +14533,9 @@
       "dev": true
     },
     "newrelic": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.6.0.tgz",
-      "integrity": "sha512-eCVrrccxkgLubAw/ovt20Yn1bcmPEs5t7w1UwKmgJISggkmS/CDjgmoHQen2cspb6ZI7AvM94dncupYbU1QLHw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.7.0.tgz",
+      "integrity": "sha512-lGTgfLvipr6QDum4f7P2BjwC3Cx9t7mvZVam/iQga/nd1723nz3fNGNnE/6Sceoye6PgXiSkLIeVOzvYGduz7w==",
       "dev": true,
       "requires": {
         "@grpc/grpc-js": "^1.2.11",
@@ -14581,6 +14581,12 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -14649,6 +14655,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -14910,6 +14924,12 @@
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "shebang-command": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -15163,6 +15183,14 @@
         "semver": "2 || 3 || 4 || 5",
         "slide": "~1.1.3",
         "util-extend": "^1.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "read-package-json": {
@@ -15369,10 +15397,12 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -17548,8 +17578,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
-    "newrelic": "^8.6.0",
+    "newrelic": "^8.7.0",
     "prettier": "^2.3.2",
     "sinon": "^7.2.3",
     "tap": "^15.0.9"
@@ -51,5 +51,8 @@
     "*.md",
     "tests/versioned/*.js",
     "tests/versioned/aws-server-stubs/**"
-  ]
+  ],
+  "dependencies": {
+    "semver": "^7.3.5"
+  }
 }

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,10 +1,22 @@
 {
-  "lastUpdated": "Mon Nov 29 2021 13:41:57 GMT-0800 (Pacific Standard Time)",
+  "lastUpdated": "Wed Jan 05 2022 11:19:10 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic AWS-SDK Instrumentation",
   "projectUrl": "https://github.com/newrelic/node-newrelic-aws-sdk",
   "includeOptDeps": false,
   "includeDev": true,
-  "dependencies": {},
+  "dependencies": {
+    "semver@7.3.5": {
+      "name": "semver",
+      "version": "7.3.5",
+      "range": "^7.3.5",
+      "licenses": "ISC",
+      "repoUrl": "https://github.com/npm/node-semver",
+      "versionedRepoUrl": "https://github.com/npm/node-semver/tree/v7.3.5",
+      "licenseFile": "node_modules/semver/LICENSE",
+      "licenseUrl": "https://github.com/npm/node-semver/blob/v7.3.5/LICENSE",
+      "licenseTextSource": "file"
+    }
+  },
   "devDependencies": {
     "@newrelic/eslint-config@0.0.2": {
       "name": "@newrelic/eslint-config",
@@ -156,15 +168,15 @@
       "publisher": "Andrey Okonetchnikov",
       "email": "andrey@okonet.ru"
     },
-    "newrelic@8.6.0": {
+    "newrelic@8.7.0": {
       "name": "newrelic",
-      "version": "8.6.0",
-      "range": "^8.6.0",
+      "version": "8.7.0",
+      "range": "^8.7.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v8.6.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v8.7.0",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v8.6.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v8.7.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
…r v3 instrumentation

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Required agent version to be `>=8.7.0` to register the instrumentation to support AWS SDK v3

## Links
Closes #117 

## Details
I tested this against using module directly as well as within agent.

**Directly in app**

```sh
npm link # in aws-sdk
npm link @newrelic/aws-sdk # in app
node -r @newrelic/aws-sdk /path/to/app.js
```

**Within agent**

```sh
npm link # in aws-sdk
npm link @newrelic/aws-sdk # in agent
npm link # in agent
npm link newrelic # in app
node -r newrelic path/to/app.js
```
Both logged entry below when agent was not 8.7.0

```json
{"v":0,"level":40,"name":"newrelic","hostname":"C02F81D3MD6P","pid":37707,"time":"2022-01-05T16:22:37.559Z","msg":"Th       e New Relic Node.js agent must be >= 8.7.0 to instrument AWS SDK v3, current version: 8.6.0","component":"Transaction       Shim","module":"NewRelicAPI"}
```