### PR TITLE
Lowered amount of versions we test for clients that end up with generic external segments

### DIFF
--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "@aws-sdk/client-api-gateway": {
           "versions": ">=3.0.0",
-          "samples": 10
+          "samples": 5
         }
       },
       "files": [
@@ -27,7 +27,7 @@
       "dependencies": {
         "@aws-sdk/client-elasticache": {
           "versions": ">=3.0.0",
-          "samples": 10
+          "samples": 2
         }
       },
       "files": [
@@ -41,7 +41,7 @@
       "dependencies": {
         "@aws-sdk/client-elastic-load-balancing": {
           "versions": ">=3.0.0",
-          "samples": 10
+          "samples": 2
         }
       },
       "files": [
@@ -55,7 +55,7 @@
       "dependencies": {
         "@aws-sdk/client-lambda": {
           "versions": ">=3.0.0",
-          "samples": 10
+          "samples": 2
         }
       },
       "files": [
@@ -69,7 +69,7 @@
       "dependencies": {
         "@aws-sdk/client-rds": {
           "versions": ">=3.0.0",
-          "samples": 10
+          "samples": 2
         }
       },
       "files": [
@@ -83,7 +83,7 @@
       "dependencies": {
         "@aws-sdk/client-redshift": {
           "versions": ">=3.0.0",
-          "samples": 10
+          "samples": 2
         }
       },
       "files": [
@@ -97,7 +97,7 @@
       "dependencies": {
         "@aws-sdk/client-rekognition": {
           "versions": ">=3.0.0",
-          "samples": 10
+          "samples": 2
         }
       },
       "files": [
@@ -111,7 +111,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": {
           "versions": ">=3.0.0",
-          "samples": 10
+          "samples": 5
         }
       },
       "files": [
@@ -125,7 +125,7 @@
       "dependencies": {
         "@aws-sdk/client-ses": {
           "versions": ">=3.0.0",
-          "samples": 10
+          "samples": 2
         }
       },
       "files": [


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

* Limited versions tested for several clients that run through the generic external segment instrumentation.

## Details


When running full versioned, the v3 tests take significantly longer
than v2 cause now we are hitting so many distinct library versions.
Several of these are just exercising our generic instrumentation to
track as an external so reducing permutations there.

Left a couple of the seemingly more important ones up at 5.