### PR TITLE
Temporarily lock down version of @aws-sdk/client-s3

### DIFF
--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -110,7 +110,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-s3": {
-          "versions": ">=3.0.0",
+          "versions": ">=3.0.0 <=v3.191.0",
           "samples": 5
         }
       },


### PR DESCRIPTION
## Proposed Release Notes
* Locked down version of aws-sdk/client-s3 to under 3.192.0, as that version is broken

## Links
https://github.com/aws/aws-sdk-js-v3/issues/4053

## Details
Version 3.192.0 released today and is busted, so until https://github.com/aws/aws-sdk-js-v3/issues/4053 is fixed, we're locking down to lower versions in the versioned tests to fix CI. Once this bug is addressed we will revert this change.