### PR TITLE
Update s3-client semver range to skip 3.192.0

### DIFF
--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -110,7 +110,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-s3": {
-          "versions": ">=3.0.0 <=v3.191.0",
+          "versions": ">=3.0.0 <=v3.191.0 || >=v3.193.0",
           "samples": 5
         }
       },


### PR DESCRIPTION
## Proposed Release Notes
Update test semver range for client-s3 to exclude version 3.192.0

## Links
https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.193.0

## Details
Follow up from #152 now that AWS has released a new version