### PR TITLE
Update versioned tests to skip 3.194.0

### DIFF
--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -26,7 +26,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-elasticache": {
-          "versions": ">=3.0.0",
+          "versions": ">=3.0.0 <=3.193.0",
           "samples": 2
         }
       },
@@ -40,7 +40,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-elastic-load-balancing": {
-          "versions": ">=3.0.0",
+          "versions": ">=3.0.0 <=3.193.0",
           "samples": 2
         }
       },
@@ -68,7 +68,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-rds": {
-          "versions": ">=3.0.0",
+          "versions": ">=3.0.0 <=3.193.0",
           "samples": 2
         }
       },
@@ -82,7 +82,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-redshift": {
-          "versions": ">=3.0.0",
+          "versions": ">=3.0.0 <=3.193.0",
           "samples": 2
         }
       },
@@ -124,7 +124,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-ses": {
-          "versions": ">=3.0.0",
+          "versions": ">=3.0.0 <=3.193.0",
           "samples": 2
         }
       },
@@ -138,7 +138,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-sns": {
-          "versions": ">=3.0.0",
+          "versions": ">=3.0.0 <=3.193.0",
           "samples": 10
         }
       },
@@ -152,7 +152,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-sqs": {
-          "versions": ">=3.0.0",
+          "versions": ">=3.0.0 <=3.193.0",
           "samples": 10
         }
       },


### PR DESCRIPTION
## Proposed Release Notes
* Updated versioned tests to exclude 3.194.0 from tests that rely on custom endpoints

## Links
https://github.com/aws/aws-sdk-js-v3/issues/4076

## Details
aws-sdk@3.194.0 broke support for custom endpoints, so stay with 3.193.0 until a fix comes out, at which point we'll have to update the semver ranges again
