### PR TITLE
NEWRELIC-4422: remove usage of __NR_instrumented in tests

### DIFF
--- a/tests/versioned/v2/instrumentation-supported.tap.js
+++ b/tests/versioned/v2/instrumentation-supported.tap.js
@@ -31,13 +31,17 @@ tap.test('instrumentation is supported', (t) => {
     AWS = null
   })
 
-  t.test('AWS should have newrelic attributes', (t) => {
-    t.assert(AWS.__NR_instrumented, 'Found __NR_instrumented')
+  t.test('AWS should be instrumented', (t) => {
+    t.equal(
+      AWS.NodeHttpClient.prototype.handleRequest.name,
+      'wrappedHandleRequest',
+      'AWS has a wrapped NodeHttpClient'
+    )
     t.end()
   })
 
   t.test('instrumentation supported function', (t) => {
-    t.assert(
+    t.ok(
       instrumentationHelper.instrumentationSupported(AWS),
       'instrumentationSupported returned true'
     )

--- a/tests/versioned/v2/instrumentation-unsupported.tap.js
+++ b/tests/versioned/v2/instrumentation-unsupported.tap.js
@@ -41,8 +41,8 @@ tap.test('instrumentation is not supported', (t) => {
   })
 
   t.test('instrumentation supported function', (t) => {
-    t.ok(
-      !instrumentationHelper.instrumentationSupported(AWS),
+    t.notOk(
+      instrumentationHelper.instrumentationSupported(AWS),
       'instrumentationSupported returned false'
     )
     t.end()

--- a/tests/versioned/v2/instrumentation-unsupported.tap.js
+++ b/tests/versioned/v2/instrumentation-unsupported.tap.js
@@ -10,7 +10,7 @@ const utils = require('@newrelic/test-utilities')
 const instrumentationHelper = require('../../../lib/v2/instrumentation-helper')
 utils.assert.extendTap(tap)
 
-tap.test('instrumentation is supported', (t) => {
+tap.test('instrumentation is not supported', (t) => {
   t.autoend()
 
   let helper = null
@@ -31,13 +31,17 @@ tap.test('instrumentation is supported', (t) => {
     AWS = null
   })
 
-  t.test('AWS should not have newrelic attributes', (t) => {
-    t.assert(!AWS.__NR_instrumented, '__NR_instrumented not present')
+  t.test('AWS should not be instrumented', (t) => {
+    t.notEqual(
+      AWS.NodeHttpClient.prototype.handleRequest.name,
+      'wrappedHandleRequest',
+      'AWS does not have a wrapped NodeHttpClient'
+    )
     t.end()
   })
 
   t.test('instrumentation supported function', (t) => {
-    t.assert(
+    t.ok(
       !instrumentationHelper.instrumentationSupported(AWS),
       'instrumentationSupported returned false'
     )


### PR DESCRIPTION
I want to remove this magic property in the agent and replace it with a proper symbol. Having it in this test is cramping my style.

## Proposed Release Notes

* Removed one usage of `__NR_instrumented` in the tests.

## Links

* NEWRELIC-4422