### PR TITLE
Add defensive code around retrieving endpoint

### DIFF
--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -44,12 +44,9 @@ function getMatchingSegments(t, segment, pattern, markedSegments = []) {
   return markedSegments
 }
 
-function registerCoreInstrumentation(helper) {
-  helper.registerInstrumentation({
-    moduleName: '@aws-sdk/smithy-client',
-    type: 'generic',
-    onResolved: require('../../lib/v3/smithy-client')
-  })
+function registerInstrumentation(agent) {
+  const hooks = require('../../nr-hooks')
+  hooks.forEach(agent.registerInstrumentation)
 }
 
 function checkExternals({ t, service, operations, tx }) {
@@ -83,6 +80,6 @@ module.exports = {
 
   checkAWSAttributes,
   getMatchingSegments,
-  registerCoreInstrumentation,
+  registerInstrumentation,
   checkExternals
 }

--- a/tests/versioned/v2/amazon-dax-client.tap.js
+++ b/tests/versioned/v2/amazon-dax-client.tap.js
@@ -29,11 +29,7 @@ tap.test('amazon-dax-client', (t) => {
 
   t.beforeEach(() => {
     helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../../lib/v2/instrumentation')
-    })
+    common.registerInstrumentation(helper)
 
     AWS = require('aws-sdk')
     const AmazonDaxClient = require('amazon-dax-client')

--- a/tests/versioned/v2/aws-sdk.tap.js
+++ b/tests/versioned/v2/aws-sdk.tap.js
@@ -8,6 +8,7 @@
 const sinon = require('sinon')
 const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
+const common = require('../common')
 utils.assert.extendTap(tap)
 
 const { createEmptyResponseServer, FAKE_CREDENTIALS } = require('../aws-server-stubs')
@@ -29,11 +30,7 @@ tap.test('aws-sdk', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../../lib/v2/instrumentation')
-    })
+    common.registerInstrumentation(helper)
     AWS = require('aws-sdk')
     AWS.config.update({ region: 'us-east-1' })
 

--- a/tests/versioned/v2/dynamodb.tap.js
+++ b/tests/versioned/v2/dynamodb.tap.js
@@ -30,11 +30,7 @@ tap.test('DynamoDB', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../../lib/v2/instrumentation')
-    })
+    common.registerInstrumentation(helper)
 
     AWS = require('aws-sdk')
 

--- a/tests/versioned/v2/http-services.tap.js
+++ b/tests/versioned/v2/http-services.tap.js
@@ -28,11 +28,7 @@ tap.test('AWS HTTP Services', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../../lib/v2/instrumentation')
-    })
+    common.registerInstrumentation(helper)
     AWS = require('aws-sdk')
     AWS.config.update({ region: 'us-east-1' })
 

--- a/tests/versioned/v2/instrumentation-supported.tap.js
+++ b/tests/versioned/v2/instrumentation-supported.tap.js
@@ -8,6 +8,7 @@
 const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 const instrumentationHelper = require('../../../lib/v2/instrumentation-helper')
+const common = require('../common')
 utils.assert.extendTap(tap)
 
 tap.test('instrumentation is supported', (t) => {
@@ -18,11 +19,7 @@ tap.test('instrumentation is supported', (t) => {
 
   t.beforeEach(() => {
     helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../../lib/v2/instrumentation')
-    })
+    common.registerInstrumentation(helper)
     AWS = require('aws-sdk')
   })
 

--- a/tests/versioned/v2/instrumentation-unsupported.tap.js
+++ b/tests/versioned/v2/instrumentation-unsupported.tap.js
@@ -8,6 +8,7 @@
 const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 const instrumentationHelper = require('../../../lib/v2/instrumentation-helper')
+const common = require('../common')
 utils.assert.extendTap(tap)
 
 tap.test('instrumentation is not supported', (t) => {
@@ -18,11 +19,7 @@ tap.test('instrumentation is not supported', (t) => {
 
   t.beforeEach(() => {
     helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../../lib/v2/instrumentation')
-    })
+    common.registerInstrumentation(helper)
     AWS = require('aws-sdk')
   })
 

--- a/tests/versioned/v2/s3.tap.js
+++ b/tests/versioned/v2/s3.tap.js
@@ -28,11 +28,7 @@ tap.test('S3 buckets', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../../lib/v2/instrumentation')
-    })
+    common.registerInstrumentation(helper)
     AWS = require('aws-sdk')
     S3 = new AWS.S3({
       credentials: FAKE_CREDENTIALS,

--- a/tests/versioned/v2/sns.tap.js
+++ b/tests/versioned/v2/sns.tap.js
@@ -29,11 +29,7 @@ tap.test('SNS', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../../lib/v2/instrumentation')
-    })
+    common.registerInstrumentation(helper)
     AWS = require('aws-sdk')
 
     sns = new AWS.SNS({

--- a/tests/versioned/v2/sqs.tap.js
+++ b/tests/versioned/v2/sqs.tap.js
@@ -36,11 +36,7 @@ tap.test('SQS API', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'aws-sdk',
-      type: 'conglomerate',
-      onRequire: require('../../../lib/v2/instrumentation')
-    })
+    common.registerInstrumentation(helper)
 
     AWS = require('aws-sdk')
 

--- a/tests/versioned/v3/api-gateway.tap.js
+++ b/tests/versioned/v3/api-gateway.tap.js
@@ -24,7 +24,7 @@ tap.test('APIGatewayClient', (t) => {
       server.listen(0, resolve)
     })
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
+    common.registerInstrumentation(helper)
     const { APIGatewayClient, ...lib } = require('@aws-sdk/client-api-gateway')
     CreateApiKeyCommand = lib.CreateApiKeyCommand
     const endpoint = `http://localhost:${server.address().port}`

--- a/tests/versioned/v3/elasticache.tap.js
+++ b/tests/versioned/v3/elasticache.tap.js
@@ -24,7 +24,7 @@ tap.test('ElastiCacheClient', (t) => {
       server.listen(0, resolve)
     })
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
+    common.registerInstrumentation(helper)
     const { ElastiCacheClient, ...lib } = require('@aws-sdk/client-elasticache')
     AddTagsToResourceCommand = lib.AddTagsToResourceCommand
     const endpoint = `http://localhost:${server.address().port}`

--- a/tests/versioned/v3/elb.tap.js
+++ b/tests/versioned/v3/elb.tap.js
@@ -24,7 +24,7 @@ tap.test('ElasticLoadBalancingClient', (t) => {
       server.listen(0, resolve)
     })
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
+    common.registerInstrumentation(helper)
     const { ElasticLoadBalancingClient, ...lib } = require('@aws-sdk/client-elastic-load-balancing')
     AddTagsCommand = lib.AddTagsCommand
     const endpoint = `http://localhost:${server.address().port}`

--- a/tests/versioned/v3/lambda.tap.js
+++ b/tests/versioned/v3/lambda.tap.js
@@ -24,7 +24,7 @@ tap.test('LambdaClient', (t) => {
       server.listen(0, resolve)
     })
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
+    common.registerInstrumentation(helper)
     const { LambdaClient, ...lib } = require('@aws-sdk/client-lambda')
     AddLayerVersionPermissionCommand = lib.AddLayerVersionPermissionCommand
     const endpoint = `http://localhost:${server.address().port}`

--- a/tests/versioned/v3/lib-dynamodb.tap.js
+++ b/tests/versioned/v3/lib-dynamodb.tap.js
@@ -31,13 +31,7 @@ tap.test('DynamoDB', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
-    helper.registerInstrumentation({
-      moduleName: '@aws-sdk/lib-dynamodb',
-      type: 'datastore',
-      onResolved: require('../../../lib/v3/lib-dynamodb')
-    })
-
+    common.registerInstrumentation(helper)
     const lib = require('@aws-sdk/lib-dynamodb')
     DynamoDBDocumentClient = lib.DynamoDBDocumentClient
     const { DynamoDBClient } = require('@aws-sdk/client-dynamodb')
@@ -53,7 +47,7 @@ tap.test('DynamoDB', (t) => {
     const endpoint = `http://localhost:${server.address().port}`
     client = new DynamoDBClient({
       credentials: FAKE_CREDENTIALS,
-      endpoint: endpoint,
+      endpoint,
       region: 'us-east-1'
     })
 

--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -12,7 +12,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-api-gateway": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 5
         }
       },
@@ -26,7 +26,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-elasticache": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 2
         }
       },
@@ -40,7 +40,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-elastic-load-balancing": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 2
         }
       },
@@ -54,7 +54,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-lambda": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 2
         }
       },
@@ -68,7 +68,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-rds": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 2
         }
       },
@@ -82,7 +82,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-redshift": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 2
         }
       },
@@ -96,7 +96,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-rekognition": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 2
         }
       },
@@ -124,7 +124,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-ses": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 2
         }
       },
@@ -138,7 +138,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-sns": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 10
         }
       },
@@ -152,7 +152,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-sqs": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 10
         }
       },
@@ -166,7 +166,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-dynamodb": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 10
         }
       },
@@ -182,7 +182,7 @@
         "@aws-sdk/util-dynamodb": "latest",
         "@aws-sdk/client-dynamodb": "latest",
         "@aws-sdk/lib-dynamodb": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.194.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
           "samples": 10
         }
       },

--- a/tests/versioned/v3/rds.tap.js
+++ b/tests/versioned/v3/rds.tap.js
@@ -24,7 +24,7 @@ tap.test('RDSClient', (t) => {
       server.listen(0, resolve)
     })
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
+    common.registerInstrumentation(helper)
     const { RDSClient, ...lib } = require('@aws-sdk/client-rds')
     AddRoleToDBClusterCommand = lib.AddRoleToDBClusterCommand
     const endpoint = `http://localhost:${server.address().port}`

--- a/tests/versioned/v3/redshift.tap.js
+++ b/tests/versioned/v3/redshift.tap.js
@@ -23,7 +23,7 @@ tap.test('RedshiftClient', (t) => {
       server.listen(0, resolve)
     })
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
+    common.registerInstrumentation(helper)
     const { RedshiftClient, ...lib } = require('@aws-sdk/client-redshift')
     AcceptReservedNodeExchangeCommand = lib.AcceptReservedNodeExchangeCommand
     const endpoint = `http://localhost:${server.address().port}`

--- a/tests/versioned/v3/rekognition.tap.js
+++ b/tests/versioned/v3/rekognition.tap.js
@@ -24,7 +24,7 @@ tap.test('RekognitionClient', (t) => {
       server.listen(0, resolve)
     })
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
+    common.registerInstrumentation(helper)
     const { RekognitionClient, ...lib } = require('@aws-sdk/client-rekognition')
     CompareFacesCommand = lib.CompareFacesCommand
     const endpoint = `http://localhost:${server.address().port}`

--- a/tests/versioned/v3/s3.tap.js
+++ b/tests/versioned/v3/s3.tap.js
@@ -30,7 +30,7 @@ tap.test('S3 buckets', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
+    common.registerInstrumentation(helper)
     const { S3Client, ...lib } = require('@aws-sdk/client-s3')
     S3 = new S3Client({
       region: 'us-east-1',

--- a/tests/versioned/v3/ses.tap.js
+++ b/tests/versioned/v3/ses.tap.js
@@ -24,7 +24,7 @@ tap.test('SESClient', (t) => {
       server.listen(0, resolve)
     })
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
+    common.registerInstrumentation(helper)
     const { SESClient, ...lib } = require('@aws-sdk/client-ses')
     SendEmailCommand = lib.SendEmailCommand
     const endpoint = `http://localhost:${server.address().port}`

--- a/tests/versioned/v3/sns.tap.js
+++ b/tests/versioned/v3/sns.tap.js
@@ -30,12 +30,7 @@ tap.test('SNS', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
-    helper.registerInstrumentation({
-      moduleName: '@aws-sdk/client-sns',
-      type: 'message',
-      onResolved: require('../../../lib/v3/sns')
-    })
+    common.registerInstrumentation(helper)
     const lib = require('@aws-sdk/client-sns')
     const SNSClient = lib.SNSClient
     PublishCommand = lib.PublishCommand

--- a/tests/versioned/v3/sqs.tap.js
+++ b/tests/versioned/v3/sqs.tap.js
@@ -35,12 +35,7 @@ tap.test('SQS API', (t) => {
     })
 
     helper = utils.TestAgent.makeInstrumented()
-    common.registerCoreInstrumentation(helper)
-    helper.registerInstrumentation({
-      moduleName: '@aws-sdk/client-sqs',
-      type: 'message',
-      onResolved: require('../../../lib/v3/sqs')
-    })
+    common.registerInstrumentation(helper)
 
     const lib = require('@aws-sdk/client-sqs')
     const SQSClient = lib.SQSClient


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed a crash when using versions >3.192.0 of AWS sdk v3 where a customer would see an error of `error: TypeError: config.endpoint is not a function`. 

## Links
 * Closes NEWRELIC-5073
 * AWS sdk team released a [breaking change in semver minor](https://github.com/aws/aws-sdk-js-v3/issues/4122)
 * Closes #160 

## Details
I added a new test that does not pass in endpoint as our versioned tests did not catch this due to changes in the aws sdk.  You can read the linked GitHub thread but the AWS sdk team removed `config.endpoint` if you do not pass in a custom endpoint.  We will now derive the endpoint from region if `config.endpoint` is not a function.  I also tweaked how we register instrumentation to rely on `nr-hooks.js` to test how the agent registers code.
