### PR TITLE
Skipping aws-sdk version 3.290.0

### DIFF
--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -12,7 +12,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-api-gateway": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 5
         }
       },
@@ -26,7 +26,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-elasticache": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 2
         }
       },
@@ -40,7 +40,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-elastic-load-balancing": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 2
         }
       },
@@ -54,7 +54,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-lambda": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 2
         }
       },
@@ -68,7 +68,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-rds": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 2
         }
       },
@@ -82,7 +82,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-redshift": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 2
         }
       },
@@ -96,7 +96,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-rekognition": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 2
         }
       },
@@ -110,7 +110,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-s3": {
-          "versions": ">=3.0.0 <=v3.191.0 || >=v3.193.0",
+          "versions": ">=3.0.0 <=v3.191.0 || >=v3.193.0 <3.290.0",
           "samples": 5
         }
       },
@@ -124,7 +124,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-ses": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 2
         }
       },
@@ -138,7 +138,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-sns": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 10
         }
       },
@@ -152,7 +152,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-sqs": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 10
         }
       },
@@ -166,7 +166,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-dynamodb": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 10
         }
       },
@@ -179,10 +179,10 @@
         "node": ">=14.0"
       },
       "dependencies": {
-        "@aws-sdk/util-dynamodb": "latest",
-        "@aws-sdk/client-dynamodb": "latest",
+        "@aws-sdk/util-dynamodb": "~3.289.0",
+        "@aws-sdk/client-dynamodb": "~3.289.0",
         "@aws-sdk/lib-dynamodb": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.290.0",
           "samples": 10
         }
       },


### PR DESCRIPTION
## Proposed Release Notes

Pinned tests to versions before breaking change in aws-sdk 3.290.0.

## Links

https://issues.newrelic.com/browse/NEWRELIC-7497

## Details

aws-sdk 3.290.0 introduced automatic lowercasing of all header names, which interfered with instrumentation. Temporarily skipping this version to unblock other repos that depend on this package.