### PR TITLE
fix: Assigned shimName to v3 instrumentation to avoid duplicate middleware crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,21 +15,26 @@ newrelic.instrumentConglomerate('aws-sdk', require('./lib/v2/instrumentation'))
 
 newrelic.instrument({
   moduleName: '@aws-sdk/smithy-client',
-  onResolved: require('./lib/v3/smithy-client')
+  onResolved: require('./lib/v3/smithy-client'),
+  shimName: 'aws-sdk'
 })
 newrelic.instrumentMessages({
   moduleName: '@aws-sdk/client-sns',
-  onResolved: require('./lib/v3/sns')
+  onResolved: require('./lib/v3/sns'),
+  shimName: 'aws-sdk'
 })
 newrelic.instrumentMessages({
   moduleName: '@aws-sdk/client-sqs',
-  onResolved: require('./lib/v3/sqs')
+  onResolved: require('./lib/v3/sqs'),
+  shimName: 'aws-sdk'
 })
 newrelic.instrumentDatastore({
   moduleName: '@aws-sdk/client-dynamodb',
-  onResolved: require('./lib/v3/client-dynamodb')
+  onResolved: require('./lib/v3/client-dynamodb'),
+  shimName: 'aws-sdk'
 })
 newrelic.instrumentDatastore({
   moduleName: '@aws-sdk/lib-dynamodb',
-  onResolved: require('./lib/v3/lib-dynamodb')
+  onResolved: require('./lib/v3/lib-dynamodb'),
+  shimName: 'aws-sdk'
 })

--- a/nr-hooks.js
+++ b/nr-hooks.js
@@ -14,27 +14,32 @@ const instrumentations = [
   {
     type: 'generic',
     moduleName: '@aws-sdk/smithy-client',
-    onResolved: require('./lib/v3/smithy-client')
+    onResolved: require('./lib/v3/smithy-client'),
+    shimName: 'aws-sdk'
   },
   {
     type: 'message',
     moduleName: '@aws-sdk/client-sns',
-    onResolved: require('./lib/v3/sns')
+    onResolved: require('./lib/v3/sns'),
+    shimName: 'aws-sdk'
   },
   {
     type: 'message',
     moduleName: '@aws-sdk/client-sqs',
-    onResolved: require('./lib/v3/sqs')
+    onResolved: require('./lib/v3/sqs'),
+    shimName: 'aws-sdk'
   },
   {
     type: 'datastore',
     moduleName: '@aws-sdk/client-dynamodb',
-    onResolved: require('./lib/v3/client-dynamodb')
+    onResolved: require('./lib/v3/client-dynamodb'),
+    shimName: 'aws-sdk'
   },
   {
     type: 'datastore',
     moduleName: '@aws-sdk/lib-dynamodb',
-    onResolved: require('./lib/v3/lib-dynamodb')
+    onResolved: require('./lib/v3/lib-dynamodb'),
+    shimName: 'aws-sdk'
   }
 ]
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Assigned shimName to v3 instrumentation to avoid duplicate middleware crashes.

## Links
Closes #181

## Details
onResolved hooks + wrapClass do not play nicely in v10 of the agent.  onResolved hooks _could_ fire more than once unlike onRequired which typically gets the exported module from require cache.  [wrapClass](https://github.com/newrelic/node-newrelic/blob/main/lib/shim/shim.js#L744) was wrapping wraps of wraps of wraps, there's no end. This causes the instrumentation to fire n times for a given class now.  The solution is to assign the `shimName` to all aws instrumentation.  This will assign all of our instrumentation the same shim id and will restore legacy functionality of isWrapped. This is very difficult to reproduce in our versioned tests but if you follow the linked bug it is easy to repro.
