### PR TITLE
chore: prevent testing on version 2.1372.0+ of aws-sdk as it has broken our instrumentation and mock server

### DIFF
--- a/tests/versioned/v2/package.json
+++ b/tests/versioned/v2/package.json
@@ -22,7 +22,7 @@
       },
       "dependencies": {
         "aws-sdk": {
-          "versions": ">=2.380.0",
+          "versions": ">=2.380.0 <2.1372.0",
           "samples": 10
         }
       },
@@ -42,7 +42,7 @@
       },
       "dependencies": {
         "aws-sdk": {
-          "versions": ">=2.380.0",
+          "versions": ">=2.380.0 <2.1372.0",
           "samples": 10
         },
         "amazon-dax-client": ">=1.2.5"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
Version [2.1372.0](https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md#213720) of aws sdk has broken both our instrumentation and mock server. I will file a ticket to address but want to unblock CI.
