### PR TITLE
skip newer versions of sqs library

### DIFF
--- a/tests/versioned/v2/package.json
+++ b/tests/versioned/v2/package.json
@@ -22,7 +22,7 @@
       },
       "dependencies": {
         "aws-sdk": {
-          "versions": ">=2.380.0 <2.1372.0",
+          "versions": ">=2.380.0",
           "samples": 10
         }
       },
@@ -32,8 +32,22 @@
         "http-services.tap.js",
         "instrumentation-supported.tap.js",
         "s3.tap.js",
-        "sqs.tap.js",
         "sns.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=14.0"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "versions": ">=2.380.0",
+          "samples": 10
+        },
+        "amazon-dax-client": ">=1.2.5"
+      },
+      "files": [
+        "amazon-dax-client.tap.js"
       ]
     },
     {
@@ -44,11 +58,10 @@
         "aws-sdk": {
           "versions": ">=2.380.0 <2.1372.0",
           "samples": 10
-        },
-        "amazon-dax-client": ">=1.2.5"
+        }
       },
       "files": [
-        "amazon-dax-client.tap.js"
+        "sqs.tap.js"
       ]
     }
   ],

--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -152,7 +152,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-sqs": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.327.0",
           "samples": 10
         }
       },


### PR DESCRIPTION

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

- chore: prevent testing on version 2.1372.0+ of aws-sdk as it has broken our instrumentation and mock server
- fixed version lockdown as it applies to both sqs in v2 and v3 of sdk

See #186
