### PR TITLE
chore: update explorer hub links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If the issue has been confirmed as a bug or is a feature request, please file a 
 
 * [New Relic and AWS](https://docs.newrelic.com/docs/accounts/install-new-relic/partner-based-installation/new-relic-aws-amazon-web-services). AWS specific agent documentation
 * [New Relic Documentation](https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs): Comprehensive guidance for using our platform
-* [New Relic Community](https://discuss.newrelic.com/tags/c/telemetry-data-platform/agents/nodeagent): The best place to engage in troubleshooting questions
+* [New Relic Community](https://forum.newrelic.com/): The best place to engage in troubleshooting questions
 * [New Relic Developer](https://developer.newrelic.com/): Resources for building a custom observability applications
 * [New Relic University](https://learn.newrelic.com/): A range of online training for New Relic users of every level
 * [New Relic Technical Support](https://support.newrelic.com/) 24/7/365 ticketed support. Read more about our [Technical Support Offerings](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/support-plan).


### PR DESCRIPTION
## Proposed Release Notes
* Updated README links to point to new forum link due to repolinter ruleset change

## Links
Part of NR-122470

## Details
