### PR TITLE
Fix instrumentation in 3.363.0 of aws sdk

### DIFF
--- a/nr-hooks.js
+++ b/nr-hooks.js
@@ -18,6 +18,12 @@ const instrumentations = [
     shimName: 'aws-sdk'
   },
   {
+    type: 'generic',
+    moduleName: '@smithy/smithy-client',
+    onResolved: require('./lib/v3/smithy-client'),
+    shimName: 'aws-sdk'
+  },
+  {
     type: 'message',
     moduleName: '@aws-sdk/client-sns',
     onResolved: require('./lib/v3/sns'),

--- a/tests/versioned/v3/client-dynamodb.tap.js
+++ b/tests/versioned/v3/client-dynamodb.tap.js
@@ -96,7 +96,11 @@ tap.test('DynamoDB', (t) => {
     DynamoDBClient = null
 
     Object.keys(require.cache).forEach((key) => {
-      if (key.includes('@aws-sdk/client-dynamodb') || key.includes('@aws-sdk/smithy-client')) {
+      if (
+        key.includes('@aws-sdk/client-dynamodb') ||
+        key.includes('@aws-sdk/smithy-client') ||
+        key.includes('@smithy/smithy-client')
+      ) {
         delete require.cache[key]
       }
     })

--- a/tests/versioned/v3/lib-dynamodb.tap.js
+++ b/tests/versioned/v3/lib-dynamodb.tap.js
@@ -70,7 +70,8 @@ tap.test('DynamoDB', (t) => {
       if (
         key.includes('@aws-sdk/lib-dynamodb') ||
         key.includes('@aws-sdk/client-dynamodb') ||
-        key.includes('@aws-sdk/smithy-client')
+        key.includes('@aws-sdk/smithy-client') ||
+        key.includes('@smithy/smithy-client')
       ) {
         delete require.cache[key]
       }

--- a/tests/versioned/v3/sns.tap.js
+++ b/tests/versioned/v3/sns.tap.js
@@ -49,7 +49,11 @@ tap.test('SNS', (t) => {
     // which files within the modules were cached preventing the instrumenting
     // from running on every test
     Object.keys(require.cache).forEach((key) => {
-      if (key.includes('@aws-sdk/client-sns') || key.includes('@aws-sdk/smithy-client')) {
+      if (
+        key.includes('@aws-sdk/client-sns') ||
+        key.includes('@aws-sdk/smithy-client') ||
+        key.includes('@smithy/smithy-client')
+      ) {
         delete require.cache[key]
       }
     })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed instrumentation in AWS 3.363.0.

## Links
Closes #194

## Details
AWS decided to rename their smithy client package to be [`@smithy` scoped](https://github.com/aws/aws-sdk-js-v3/pull/4873).  Thankfully this was a quick fix.
