### PR TITLE
ci: skip version 3.377.0 of aws sdk packages as they are broken

### DIFF
--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -12,7 +12,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-api-gateway": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 5
         }
       },
@@ -26,7 +26,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-elasticache": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 2
         }
       },
@@ -40,7 +40,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-elastic-load-balancing": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 2
         }
       },
@@ -54,7 +54,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-lambda": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 2
         }
       },
@@ -68,7 +68,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-rds": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 2
         }
       },
@@ -82,7 +82,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-redshift": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 2
         }
       },
@@ -96,7 +96,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-rekognition": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 2
         }
       },
@@ -110,7 +110,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-s3": {
-          "versions": ">=3.0.0 <=v3.191.0 || >=v3.193.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 5
         }
       },
@@ -124,7 +124,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-ses": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 2
         }
       },
@@ -138,7 +138,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-sns": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 10
         }
       },
@@ -152,7 +152,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-sqs": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 10
         }
       },
@@ -166,7 +166,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-dynamodb": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 10
         }
       },
@@ -182,7 +182,7 @@
         "@aws-sdk/util-dynamodb": "latest",
         "@aws-sdk/client-dynamodb": "latest",
         "@aws-sdk/lib-dynamodb": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0",
+          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 10
         }
       },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
Yet another aws sdk release broke things.  [3.377.0](https://github.com/aws/aws-sdk-js-v3/issues/5014) is not usable so this PR skips it and preemptively includes future releases.
