### PR TITLE
fix: Updated aws-sdk v3 instrumentation to only call `shim.setLibrary` and `shim.setDatastore` once instead of on every call to sqs/sns/dyanmodb

### DIFF
--- a/lib/v3/dynamodb.js
+++ b/lib/v3/dynamodb.js
@@ -54,7 +54,6 @@ async function getEndpoint(config) {
  * @returns {function}
  */
 function dynamoMiddleware(shim, config, next, context) {
-  shim.setDatastore(shim.DYNAMODB)
   const { commandName } = context
   return async function wrappedMiddleware(args) {
     let endpoint = null
@@ -72,6 +71,9 @@ function dynamoMiddleware(shim, config, next, context) {
 
 const dynamoMiddlewareConfig = {
   middleware: dynamoMiddleware,
+  init(shim) {
+    shim.setDatastore(shim.DYNAMODB)
+  },
   type: 'datastore',
   config: {
     name: 'NewRelicDynamoMiddleware',

--- a/lib/v3/smithy-client.js
+++ b/lib/v3/smithy-client.js
@@ -50,6 +50,7 @@ function wrapSend(shim, send) {
         // copy the shim id from parent so if you check if something is wrapped
         // it will be across all instrumentation
         localShim.assignId('aws-sdk')
+        mw.init && mw.init(localShim)
         const middleware = mw.middleware.bind(null, localShim, config)
         this.middlewareStack.add(middleware, mw.config)
       }

--- a/lib/v3/sns.js
+++ b/lib/v3/sns.js
@@ -15,7 +15,6 @@
  * @returns {function}
  */
 function snsMiddleware(shim, config, next, context) {
-  shim.setLibrary(shim.SNS)
   if (context.commandName === 'PublishCommand') {
     return shim.recordProduce(next, getSnsSpec)
   }
@@ -55,6 +54,9 @@ function getDestinationName({ TopicArn, TargetArn }) {
 
 module.exports.snsMiddlewareConfig = {
   middleware: snsMiddleware,
+  init(shim) {
+    shim.setLibrary(shim.SNS)
+  },
   type: 'message',
   config: {
     name: 'NewRelicSnsMiddleware',

--- a/lib/v3/sqs.js
+++ b/lib/v3/sqs.js
@@ -21,7 +21,6 @@ const RECEIVE_COMMANDS = ['ReceiveMessageCommand']
  * @returns {function}
  */
 function sqsMiddleware(shim, config, next, context) {
-  shim.setLibrary(shim.SQS)
   if (SEND_COMMANDS.includes(context.commandName)) {
     return shim.recordProduce(next, getSqsSpec)
   } else if (RECEIVE_COMMANDS.includes(context.commandName)) {
@@ -53,6 +52,9 @@ function getSqsSpec(shim, original, name, args) {
 
 module.exports.sqsMiddlewareConfig = {
   middleware: sqsMiddleware,
+  init(shim) {
+    shim.setLibrary(shim.SQS)
+  },
   type: 'message',
   config: {
     name: 'NewRelicSnsMiddleware',


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated aws-sdk v3 instrumentation to only call `shim.setLibrary` and `shim.setDatastore` once instead of on every call to SQS, SNS, and DynamoDB.

## Links
Closes #218

## Details
You can see the details from my analysis [here](https://github.com/newrelic/node-newrelic-aws-sdk/issues/218#issuecomment-1843329089). Big thanks to @jsumners-nr for pointing me in the right direction from the start. It made for a quick fix, the tests were the tricky part. If you undid the code side the tests would fail as the relevant `setLibrary` or `setDatastore` would be called n times vs just once. 
