### PR TITLE
test: pin peer dep of @aws-sdk/client-dynamodb so the older versions of @aws-sdk/lib-dynamodb pass

### DIFF
--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -180,7 +180,7 @@
       },
       "dependencies": {
         "@aws-sdk/util-dynamodb": "latest",
-        "@aws-sdk/client-dynamodb": "latest",
+        "@aws-sdk/client-dynamodb": "3.476.0",
         "@aws-sdk/lib-dynamodb": {
           "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
           "samples": 10
@@ -193,3 +193,4 @@
   ],
   "dependencies": {}
 }
+


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
We had failing versioned tests runs on [main of the agent](https://github.com/newrelic/node-newrelic/actions/runs/7277973871/job/19831177371). I traced it back to a change in 3.477.0 of [@aws-sdk/client-dynamodb](https://github.com/aws/aws-sdk-js-v3/pull/5284/files#diff-e15f91f7125819d820715e6b02e5bce9a1e7dd89c67a4ed348be8c6117396d49).  For now we will have to pin that peer dep until it becomes a problem.  These packages no longer follow semver so this is the nonsense we have to deal with at times.  
