### PR TITLE
ci: Updated prepare-release to use conventional commit based releases.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,14 +6,22 @@ This code is leveraged to monitor critical services. Please consider the followi
 * Performance matters.
 * Features that are specific to just your app are unlikely to make it in.
 
-Please fill out the relevant sections as follows:
-* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
-* Links: Any relevant links for the change.
-* Details: In-depth description of changes, other technical notes, etc.
+Ensure that your Pull Request title adheres to our Conventional Commit standards
+as described in CONTRIBUTING.md
+
+Please update the Pull Request description to add relevant context or documentation about
+the submitted change.
 -->
+## Description
 
-## Proposed Release Notes
+Please provide a brief description of the changes introduced in this pull request.
+What problem does it solve? What is the context of this change?
 
-## Links
+## How to Test
 
-## Details
+Please describe how you have tested these changes. Have you run the code against an example application?
+What steps did you take to ensure that the changes are working correctly?
+
+## Related Issues
+
+Please include any related issues or pull requests in this section, using the format `Closes #<issue number>` or `Fixes #<issue number>` if applicable.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    # Disable version updates for npm dependencies, security updates don't use this configuration
+    # See: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
+    open-pull-requests-limit: 0
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "security"
+      prefix-development: "chore"
+      include: "scope"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -6,11 +6,17 @@ on:
       release_type:
         description: Type of release. patch or minor (major if breaking)
         required: true
+        type: choice
         default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   release-notes:
     uses: newrelic/node-newrelic/.github/workflows/prep-release.yml@main
     with:
       release_type: ${{ github.event.inputs.release_type }}
+      use_new_relase: ${{ vars.USE_NEW_RELEASE }}
       changelog_file: CHANGELOG.md

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,53 @@
+name: Validate Pull Request
+
+permissions:
+  pull-requests: write
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull Request Title is Conventional
+        id: lint_pr_title
+        uses: amannn/action-semantic-pull-request@v5
+        with:
+          # Recommended Prefixes from https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/README.md#type-enum
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            security
+            style
+            test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: failure()
+        name: Add PR comment if failed
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          message: |
+            Thank you for your contribution! We require all PR titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+            Please update your PR title with the appropriate type and we'll try again!
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message}}
+            ```
+      - if: success()
+        name: Remove PR comment if valid
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:   
+          header: pr-title-lint-error
+          delete: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,30 @@ If you’re planning on contributing a new feature or an otherwise complex contr
 
 In general, we try to limit adding third-party production dependencies. If one is necessary, please be prepared to make a clear case for the need.
 
+### Commit Guidelines
+
+We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) to format commit messages for this repository. Conventional Commits provide a standardized format for commit messages that allows for automatic generation of changelogs and easy tracking of changes.
+
+When contributing to this repository, please ensure that your commit messages adhere to the Conventional Commit guidelines. Specifically, your commit messages should:
+
+* Start with a type, indicating the kind of change being made (e.g. `feat` for a new feature, `fix` for a bugfix, etc.). The types we support are:
+  * `build`: changes that affect the build system or external dependencies
+  * `chore`: changes that do not modify source or test files
+  * `ci`: changes to our CI configuration files and scripts
+  * `docs`: documentation additions or updates
+  * `feat`: new features or capabilities added to the agent
+  * `fix`: bugfixes or corrections to existing functionality
+  * `perf`: performance improvements
+  * `refactor`: changes that do not add new feature or fix bugs, but improve code structure or readability
+  * `revert`: revert a previous commit
+  * `security`: changes related to the security of the agent, including the updating of dependencies due to CVE
+  * `style` - changes that do not affect the meaning of the code (e.g. formatting, white-space, etc.)
+  * `test` - adding new tests or modifying existing tests
+* Use the imperative, present tense (e.g. "add feature" instead of "added feature")
+* Optionally, include a scope in parantheses after the type to indicate which part of the repository is affected (e.g. `feat(instrumentation): add support for Prisma Client`)
+
+Please note that we use the [Squash and Merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) method when merging Pull Requests into the main branch. We do not use the original commit messages from each individual commit. Instead, we use the Pull Request title as the commit message for the squashed commit, and as such, require that the Pull Request title adheres to our Conventional Commit standards. Any additional documentation or information relevant to the release notes should be added to the "optional extended description" section of the squash commit on merge.
+
 ### Coding Style Guidelines/Conventions
 
 We use eslint to enforce certain coding standards. Please see our [.eslintrc](./.eslintrc.js) file for specific rule configuration.

--- a/changelog.json
+++ b/changelog.json
@@ -1,0 +1,5 @@
+{
+  "repository": "newrelic/node-newrelic-aws-sdk",
+  "entries": []
+}
+


### PR DESCRIPTION
Since we are going to be doing more work in here I updated the release style to our conventional commit based workflow. I also added the validate-pr workflow and updated the PR template to no longer rely on convention in the PR description to derive changelogs.
