### PR TITLE
chore: use latest of test deps for bedrock versioned tests

### DIFF
--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -196,8 +196,8 @@
       },
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.474.0",
-        "@smithy/eventstream-codec": "^2.0.15",
-        "@smithy/util-utf8": "^2.0.2"
+        "@smithy/eventstream-codec": "latest",
+        "@smithy/util-utf8": "latest"
       },
       "files": [
         "bedrock-ai21.tap.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Currently it is ok because there are only a few versions of `@smithy/eventstream-codec` and `@smity/util-utf8` but as this grows the combination of the the 3 libraries will make a lot of unnecessary test runs.
