### PR TITLE
feat: Added ability to store feedback ids by request id

### DIFF
--- a/lib/llm/bedrock-response.js
+++ b/lib/llm/bedrock-response.js
@@ -136,7 +136,7 @@ class BedrockResponse {
    * @returns {string}
    */
   get requestId() {
-    return this.#innerOutput.requestId
+    return this.headers?.['x-amzn-requestid']
   }
 
   /**

--- a/lib/llm/event.js
+++ b/lib/llm/event.js
@@ -64,7 +64,7 @@ class LlmEvent {
     this.span_id = segment.id
     this.transaction_id = segment.transaction.id
     this.trace_id = segment.transaction.traceId
-    this.request_id = this.bedrockResponse.headers['x-amzn-requestid']
+    this.request_id = this.bedrockResponse.requestId
 
     this['response.model'] = this.bedrockCommand.modelId
     this['request.model'] = this.bedrockCommand.modelId

--- a/lib/llm/index.js
+++ b/lib/llm/index.js
@@ -11,5 +11,6 @@ module.exports = {
   LlmChatCompletionMessage: require('./chat-completion-message'),
   LlmChatCompletionSummary: require('./chat-completion-summary'),
   LlmEmbedding: require('./embedding'),
-  LlmEvent: require('./event')
+  LlmEvent: require('./event'),
+  LlmTrackedIds: require('./tracked-ids')
 }

--- a/lib/llm/tracked-ids.js
+++ b/lib/llm/tracked-ids.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * Represents the identifiers created and collected when creating LLM
+ * chat completions.
+ *
+ * @property {string[]} [message_ids=[]] Internal identifiers for each message
+ * sent in the conversation.
+ * @property {string} [coversation_id=""] User defined identifier of the chat
+ * completion conversation.
+ * @property {string} request_id Identifier of the request from the remote
+ * service for a chat completion. Populated by the `x-request-id` header
+ * in the request.
+ * @public
+ */
+module.exports = class LlmTrackedIds {
+  constructor({ messageIds, conversationId = '', requestId } = {}) {
+    this.message_ids = messageIds ?? []
+    this.conversation_id = conversationId
+    this.request_id = requestId
+  }
+}

--- a/tests/unit/llm/bedrock-response.tap.js
+++ b/tests/unit/llm/bedrock-response.tap.js
@@ -57,13 +57,13 @@ tap.beforeEach((t) => {
     response: {
       statusCode: 200,
       headers: {
+        'x-amzn-requestid': 'aws-request-1',
         'x-foo': 'foo',
         ['x-amzn-bedrock-input-token-count']: 25,
         ['x-amzn-bedrock-output-token-count']: 25
       }
     },
     output: {
-      requestId: 'aws-request-1',
       body: new TextEncoder().encode('{"foo":"foo"}')
     }
   }
@@ -100,7 +100,7 @@ tap.test('non-conforming response is handled gracefully', async (t) => {
   t.equal(res.id, undefined)
   t.equal(res.inputTokenCount, 0)
   t.equal(res.outputTokenCount, 0)
-  t.equal(res.requestId, 'aws-request-1')
+  t.equal(res.requestId, undefined)
   t.equal(res.statusCode, 200)
 })
 

--- a/tests/unit/llm/event.tap.js
+++ b/tests/unit/llm/event.tap.js
@@ -46,9 +46,7 @@ tap.beforeEach((t) => {
   }
 
   t.context.bedrockResponse = {
-    headers: {
-      'x-amzn-requestid': 'request-1'
-    }
+    requestId: 'request-1'
   }
 
   t.context.bedrockCommand = {

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -117,6 +117,7 @@ function assertChatCompletionSummary({ tx, modelId, chatSummary, tokenUsage, err
     'id': /[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}/,
     'appName': 'New Relic for Node.js tests',
     'request_id': 'eda0760a-c3f0-4fc1-9a1e-75559d642866',
+    'conversation_id': 'convo-id',
     'trace_id': tx.traceId,
     'span_id': tx.trace.root.children[0].id,
     'transaction_id': tx.id,
@@ -128,6 +129,8 @@ function assertChatCompletionSummary({ tx, modelId, chatSummary, tokenUsage, err
     'api_key_last_four_digits': 'E ID',
     'response.number_of_messages': 2,
     'response.choices.finish_reason': 'endoftext',
+    'request.temperature': 0.5,
+    'request.max_tokens': 100,
     'error': error
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
**Note**: In openai we keyed by the response id but AWS Bedrock lacks a response id.  However, they do have a unique id on every chat completion which is the request id.

Added `agent.llm.responses` for every chat completion message. Added a versioned tests that uses the agent APIs to `getLlmMessageIds` and `recordLlmFeedbackEvent` to verify it all works.  I also added temperature and max tokens to every request to ensure these are getting set on the LLM events.  
