### PR TITLE
refactor: adds a serialize method to LlmEvent to remove the complex objects before enqueuing to the custom event aggregator

### DIFF
--- a/lib/llm/event.js
+++ b/lib/llm/event.js
@@ -92,6 +92,16 @@ class LlmEvent {
     const attrs = tx?.trace?.custom.get(0x01 | 0x02 | 0x04 | 0x08)
     return attrs?.['llm.conversation_id']
   }
+
+  /**
+   * Removes the complex objects from the event
+   * This will be called right before the event is enqueued to the custom event aggregator
+   */
+  serialize() {
+    delete this.bedrockCommand
+    delete this.bedrockResponse
+    delete this.constructionParams
+  }
 }
 
 module.exports = LlmEvent

--- a/lib/v3/bedrock.js
+++ b/lib/v3/bedrock.js
@@ -34,6 +34,7 @@ function shouldSkipInstrumentation(config) {
  * @param {object} params.msg LLM event
  */
 function recordEvent({ agent, type, msg }) {
+  msg.serialize()
   agent.customEventAggregator.add([{ type, timestamp: Date.now() }, msg])
 }
 

--- a/tests/unit/llm/event.tap.js
+++ b/tests/unit/llm/event.tap.js
@@ -71,3 +71,12 @@ tap.test('create creates a new instance', async (t) => {
   t.equal(event['request.max_tokens'], null)
   t.equal(event.error, false)
 })
+
+tap.test('serializes the event', (t) => {
+  const event = new LlmEvent(t.context)
+  event.serialize()
+  t.notOk(event.bedrockCommand)
+  t.notOk(event.bedrockResponse)
+  t.notOk(event.constructionParams)
+  t.end()
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

I tried to test what we have to date with our example app and it was failing because the custom event aggregator payload sizes were very big.  I realized it was because the constructionParams, bedrockCommand and bedrockResponse were included in the event.  The actual issue was really the agent in constructionParams but we should remove these props before sending off to the aggregator.
