### PR TITLE
fix: Added override setting to middleware configuration

### DIFF
--- a/lib/v3/bedrock.js
+++ b/lib/v3/bedrock.js
@@ -289,6 +289,7 @@ module.exports.bedrockMiddlewareConfig = {
   type: 'generic',
   config: {
     name: 'NewRelicBedrockMiddleware',
-    step: 'deserialize'
+    step: 'deserialize',
+    override: true
   }
 }

--- a/lib/v3/common.js
+++ b/lib/v3/common.js
@@ -82,7 +82,8 @@ module.exports.middlewareConfig = [
     config: {
       name: 'NewRelicHeader',
       step: 'finalizeRequest',
-      priority: 'low'
+      priority: 'low',
+      override: true
     }
   },
   {
@@ -90,7 +91,8 @@ module.exports.middlewareConfig = [
     type: 'generic',
     config: {
       name: 'NewRelicDeserialize',
-      step: 'deserialize'
+      step: 'deserialize',
+      override: true
     }
   }
 ]

--- a/lib/v3/dynamodb.js
+++ b/lib/v3/dynamodb.js
@@ -79,7 +79,8 @@ const dynamoMiddlewareConfig = {
   config: {
     name: 'NewRelicDynamoMiddleware',
     step: 'initialize',
-    priority: 'high'
+    priority: 'high',
+    override: true
   }
 }
 

--- a/lib/v3/sns.js
+++ b/lib/v3/sns.js
@@ -62,6 +62,7 @@ module.exports.snsMiddlewareConfig = {
   config: {
     name: 'NewRelicSnsMiddleware',
     step: 'initialize',
-    priority: 'high'
+    priority: 'high',
+    override: true
   }
 }

--- a/lib/v3/sqs.js
+++ b/lib/v3/sqs.js
@@ -60,6 +60,7 @@ module.exports.sqsMiddlewareConfig = {
   config: {
     name: 'NewRelicSnsMiddleware',
     step: 'initialize',
-    priority: 'high'
+    priority: 'high',
+    override: true
   }
 }

--- a/tests/versioned/v3/lib-dynamodb.tap.js
+++ b/tests/versioned/v3/lib-dynamodb.tap.js
@@ -146,6 +146,7 @@ tap.test('DynamoDB', (t) => {
 
   t.test('calling send on client and doc client', (t) => {
     const docClientFrom = DynamoDBDocumentClient.from(client)
+    let errorOccurred = false
     helper.runInTransaction(async function (tx) {
       for (let i = 0; i < tests.length; i++) {
         const cfg = tests[i]
@@ -155,14 +156,15 @@ tap.test('DynamoDB', (t) => {
           await docClientFrom.send(new ddbCommands[cfg.command](cfg.params))
           await client.send(new ddbCommands[cfg.command](cfg.params))
         } catch (err) {
+          errorOccurred = true
           t.error(err)
         }
       }
 
-      tx.end()
+      t.notOk(errorOccurred, 'should not have a middleware error with two clients')
 
-      const args = [t, tests, tx]
-      setImmediate(finish, ...args)
+      tx.end()
+      t.end()
     })
   })
 

--- a/tests/versioned/v3/lib-dynamodb.tap.js
+++ b/tests/versioned/v3/lib-dynamodb.tap.js
@@ -144,6 +144,28 @@ tap.test('DynamoDB', (t) => {
     })
   })
 
+  t.test('calling send on client and doc client', (t) => {
+    const docClientFrom = DynamoDBDocumentClient.from(client)
+    helper.runInTransaction(async function (tx) {
+      for (let i = 0; i < tests.length; i++) {
+        const cfg = tests[i]
+        t.comment(`Testing ${cfg.operation}`)
+
+        try {
+          await docClientFrom.send(new ddbCommands[cfg.command](cfg.params))
+          await client.send(new ddbCommands[cfg.command](cfg.params))
+        } catch (err) {
+          t.error(err)
+        }
+      }
+
+      tx.end()
+
+      const args = [t, tests, tx]
+      setImmediate(finish, ...args)
+    })
+  })
+
   t.test('DynamoDBDocument client from commands', (t) => {
     const docClientFrom = DynamoDBDocument.from(client)
     helper.runInTransaction(async function (tx) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Added `override: true` to middleware config for bedrock, dynamodb, sns and sqs. This allows us to override the middleware with the same name. 

Example use case: when using both `DynamoDBClient` and `DynamoDBDocumentClient` in the same project, a duplicate middleware name error is thrown. 

## How to Test

Added versioned test. 

## Related Issues

Closes issue https://github.com/newrelic/node-newrelic/issues/2071