### PR TITLE
ci: Updated CI workflows to run `npm ci` instead of `npm install` to catch package-lock.json being out of sync

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
-      run: npm install
+      run: npm ci
     - name: Run Linting
       run: npm run lint
     - name: Inspect Lockfile
@@ -37,7 +37,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
-      run: npm install
+      run: npm ci
     - name: Run Unit Tests
       run: npm run unit
     - name: Post Unit Test Coverage
@@ -62,7 +62,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
-      run: npm install
+      run: npm ci
     - name: Run Versioned Tests
       run: npm run versioned
     - name: Post Versioned Test Coverage


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
We had an issue where some jobs are using `npm ci`, specifically Create Release.  It failed because the lock file was out of sync. Most of our repos run `npm ci` to install deps so this PR updates the CI job to do that instead of npm install.
