### PR TITLE
chore: Removed unused attributes on LlmChatCompletionSummary and LlmEmbedding

### DIFF
--- a/lib/llm/bedrock-response.js
+++ b/lib/llm/bedrock-response.js
@@ -123,25 +123,6 @@ class BedrockResponse {
   }
 
   /**
-   * The number of tokens present in the prompt as determined by the remote
-   * API.
-   *
-   * @returns {number|undefined}
-   */
-  get inputTokenCount() {
-    return this.#tokenCount('x-amzn-bedrock-input-token-count')
-  }
-
-  /**
-   * The number of tokens in the LLM response as determined by the remote API.
-   *
-   * @returns {number|undefined}
-   */
-  get outputTokenCount() {
-    return this.#tokenCount('x-amzn-bedrock-output-token-count')
-  }
-
-  /**
    * UUID assigned to the initial request as returned by the API.
    *
    * @returns {string}

--- a/lib/llm/chat-completion-summary.js
+++ b/lib/llm/chat-completion-summary.js
@@ -28,17 +28,11 @@ class LlmChatCompletionSummary extends LlmEvent {
     this.duration = segment.getDurationInMillis()
     this['request.max_tokens'] = this.bedrockCommand.maxTokens
 
-    const utt = 'response.usage.total_tokens'
     const nm = 'response.number_of_messages'
-    const upt = 'response.usage.prompt_tokens'
-    const uct = 'response.usage.completion_tokens'
     const cfr = 'response.choices.finish_reason'
     const rt = 'request.temperature'
 
     const cmd = this.bedrockCommand
-    this[uct] = this.bedrockResponse.outputTokenCount
-    this[upt] = this.bedrockResponse.inputTokenCount
-    this[utt] = this[upt] + this[uct]
     this[cfr] = this.bedrockResponse.finishReason
     this[rt] = cmd.temperature
     this[nm] = 1 + this.bedrockResponse.completions.length

--- a/lib/llm/embedding.js
+++ b/lib/llm/embedding.js
@@ -20,15 +20,16 @@ class LlmEmbedding extends LlmEvent {
   constructor(params = defaultParams) {
     super(params)
     const { agent } = params
+    const tokenCb = agent?.llm?.tokenCountCallback
 
     this.input = agent.config?.ai_monitoring?.record_content?.enabled
       ? this.bedrockCommand.prompt
       : undefined
     this.error = params.isError
     this.duration = params.segment.getDurationInMillis()
-    this['response.usage.total_tokens'] = this.bedrockResponse.inputTokenCount
-    this['response.usage.prompt_tokens'] = this.bedrockResponse.inputTokenCount
-    this.token_count = this.bedrockResponse.inputTokenCount
+    if (typeof tokenCb === 'function') {
+      this.token_count = tokenCb(this.bedrockCommand.modelId, this.bedrockCommand.prompt)
+    }
   }
 }
 

--- a/lib/llm/event.js
+++ b/lib/llm/event.js
@@ -56,7 +56,6 @@ class LlmEvent {
     this.ingest_source = 'Node'
     this.appName = agent.config.applications()[0]
     this.span_id = segment.id
-    this.transaction_id = segment.transaction.id
     this.trace_id = segment.transaction.traceId
     this.request_id = this.bedrockResponse.requestId
     this.metadata = agent

--- a/lib/llm/stream-handler.js
+++ b/lib/llm/stream-handler.js
@@ -181,10 +181,7 @@ class StreamHandler {
       return
     }
 
-    const metrics = parsedEvent['amazon-bedrock-invocationMetrics']
     this.response.response.headers = {
-      'x-amzn-bedrock-input-token-count': metrics.inputTokenCount,
-      'x-amzn-bedrock-output-token-count': metrics.outputTokenCount,
       'x-amzn-requestid': this.passThroughParams.response.response.headers['x-amzn-requestid']
     }
     delete parsedEvent['amazon-bedrock-invocationMetrics']

--- a/tests/unit/llm/bedrock-response.tap.js
+++ b/tests/unit/llm/bedrock-response.tap.js
@@ -58,9 +58,7 @@ tap.beforeEach((t) => {
       statusCode: 200,
       headers: {
         'x-amzn-requestid': 'aws-request-1',
-        'x-foo': 'foo',
-        ['x-amzn-bedrock-input-token-count']: 25,
-        ['x-amzn-bedrock-output-token-count']: 25
+        'x-foo': 'foo'
       }
     },
     output: {
@@ -98,8 +96,6 @@ tap.test('non-conforming response is handled gracefully', async (t) => {
   t.equal(res.finishReason, undefined)
   t.same(res.headers, undefined)
   t.equal(res.id, undefined)
-  t.equal(res.inputTokenCount, undefined)
-  t.equal(res.outputTokenCount, undefined)
   t.equal(res.requestId, undefined)
   t.equal(res.statusCode, 200)
 })
@@ -111,8 +107,6 @@ tap.test('ai21 malformed responses work', async (t) => {
   t.equal(res.finishReason, undefined)
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, undefined)
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })
@@ -125,8 +119,6 @@ tap.test('ai21 complete responses work', async (t) => {
   t.equal(res.finishReason, 'done')
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, 'ai21-response-1')
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })
@@ -138,8 +130,6 @@ tap.test('claude malformed responses work', async (t) => {
   t.equal(res.finishReason, undefined)
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, undefined)
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })
@@ -152,8 +142,6 @@ tap.test('claude complete responses work', async (t) => {
   t.equal(res.finishReason, 'done')
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, undefined)
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })
@@ -165,8 +153,6 @@ tap.test('cohere malformed responses work', async (t) => {
   t.equal(res.finishReason, undefined)
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, undefined)
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })
@@ -179,8 +165,6 @@ tap.test('cohere complete responses work', async (t) => {
   t.equal(res.finishReason, 'done')
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, 'cohere-response-1')
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })
@@ -192,8 +176,6 @@ tap.test('llama2 malformed responses work', async (t) => {
   t.equal(res.finishReason, undefined)
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, undefined)
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })
@@ -206,8 +188,6 @@ tap.test('llama2 complete responses work', async (t) => {
   t.equal(res.finishReason, 'done')
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, undefined)
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })
@@ -219,8 +199,6 @@ tap.test('titan malformed responses work', async (t) => {
   t.equal(res.finishReason, undefined)
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, undefined)
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })
@@ -233,8 +211,6 @@ tap.test('titan complete responses work', async (t) => {
   t.equal(res.finishReason, 'done')
   t.same(res.headers, t.context.response.response.headers)
   t.equal(res.id, undefined)
-  t.equal(res.inputTokenCount, 25)
-  t.equal(res.outputTokenCount, 25)
   t.equal(res.requestId, 'aws-request-1')
   t.equal(res.statusCode, 200)
 })

--- a/tests/unit/llm/chat-completion-message.tap.js
+++ b/tests/unit/llm/chat-completion-message.tap.js
@@ -13,6 +13,7 @@ const LlmChatCompletionMessage = require('../../../lib/llm/chat-completion-messa
 
 tap.beforeEach((t) => {
   t.context.agent = {
+    llm: {},
     config: {
       applications() {
         return ['test-app']
@@ -85,6 +86,7 @@ tap.beforeEach((t) => {
 })
 
 tap.test('create creates a non-response instance', async (t) => {
+  t.context.agent.llm.tokenCountCallback = () => 3
   const event = new LlmChatCompletionMessage(t.context)
   t.equal(event.is_response, false)
   t.equal(event['llm.conversation_id'], 'conversation-1')
@@ -93,6 +95,7 @@ tap.test('create creates a non-response instance', async (t) => {
   t.equal(event.content, 'who are you')
   t.equal(event.role, 'user')
   t.match(event.id, /[\w-]{36}/)
+  t.equal(event.token_count, 3)
 })
 
 tap.test('create creates a titan response instance', async (t) => {

--- a/tests/unit/llm/chat-completion-summary.tap.js
+++ b/tests/unit/llm/chat-completion-summary.tap.js
@@ -70,9 +70,7 @@ tap.beforeEach((t) => {
       'x-amzn-request-id': 'aws-request-1'
     },
     finishReason: 'done',
-    completions: ['completion-1'],
-    inputTokenCount: 25,
-    outputTokenCount: 25
+    completions: ['completion-1']
   }
 })
 
@@ -85,9 +83,6 @@ tap.test('creates a basic summary', async (t) => {
   t.equal(event['request.max_tokens'], 25)
   t.equal(event['request.temperature'], 0.5)
   t.equal(event['response.choices.finish_reason'], 'done')
-  t.equal(event['response.usage.total_tokens'], 0)
-  t.equal(event['response.usage.prompt_tokens'], 0)
-  t.equal(event['response.usage.completion_tokens'], 0)
   t.equal(event['response.number_of_messages'], 2)
 })
 
@@ -99,9 +94,6 @@ tap.test('creates an ai21 summary', async (t) => {
   t.equal(event['request.max_tokens'], 25)
   t.equal(event['request.temperature'], 0.5)
   t.equal(event['response.choices.finish_reason'], 'done')
-  t.equal(event['response.usage.total_tokens'], 50)
-  t.equal(event['response.usage.prompt_tokens'], 25)
-  t.equal(event['response.usage.completion_tokens'], 25)
   t.equal(event['response.number_of_messages'], 2)
 })
 
@@ -113,9 +105,6 @@ tap.test('creates an claude summary', async (t) => {
   t.equal(event['request.max_tokens'], 25)
   t.equal(event['request.temperature'], 0.5)
   t.equal(event['response.choices.finish_reason'], 'done')
-  t.equal(event['response.usage.total_tokens'], 50)
-  t.equal(event['response.usage.prompt_tokens'], 25)
-  t.equal(event['response.usage.completion_tokens'], 25)
   t.equal(event['response.number_of_messages'], 2)
 })
 
@@ -127,9 +116,6 @@ tap.test('creates a cohere summary', async (t) => {
   t.equal(event['request.max_tokens'], 25)
   t.equal(event['request.temperature'], 0.5)
   t.equal(event['response.choices.finish_reason'], 'done')
-  t.equal(event['response.usage.total_tokens'], 50)
-  t.equal(event['response.usage.prompt_tokens'], 25)
-  t.equal(event['response.usage.completion_tokens'], 25)
   t.equal(event['response.number_of_messages'], 2)
 })
 
@@ -141,9 +127,6 @@ tap.test('creates a llama2 summary', async (t) => {
   t.equal(event['request.max_tokens'], 25)
   t.equal(event['request.temperature'], 0.5)
   t.equal(event['response.choices.finish_reason'], 'done')
-  t.equal(event['response.usage.total_tokens'], 50)
-  t.equal(event['response.usage.prompt_tokens'], 25)
-  t.equal(event['response.usage.completion_tokens'], 25)
   t.equal(event['response.number_of_messages'], 2)
 })
 
@@ -155,8 +138,5 @@ tap.test('creates a titan summary', async (t) => {
   t.equal(event['request.max_tokens'], 25)
   t.equal(event['request.temperature'], 0.5)
   t.equal(event['response.choices.finish_reason'], 'done')
-  t.equal(event['response.usage.total_tokens'], 50)
-  t.equal(event['response.usage.prompt_tokens'], 25)
-  t.equal(event['response.usage.completion_tokens'], 25)
   t.equal(event['response.number_of_messages'], 2)
 })

--- a/tests/unit/llm/event.tap.js
+++ b/tests/unit/llm/event.tap.js
@@ -40,7 +40,6 @@ tap.beforeEach((t) => {
   t.context.segment = {
     id: 'segment-1',
     transaction: {
-      id: 'tx-1',
       traceId: 'trace-1'
     }
   }
@@ -62,7 +61,6 @@ tap.test('create creates a new instance', async (t) => {
   t.equal(event.ingest_source, 'Node')
   t.equal(event.appName, 'test-app')
   t.equal(event.span_id, 'segment-1')
-  t.equal(event.transaction_id, 'tx-1')
   t.equal(event.trace_id, 'trace-1')
   t.equal(event.request_id, 'request-1')
   t.equal(event['response.model'], 'model-1')

--- a/tests/unit/llm/stream-handler.tap.js
+++ b/tests/unit/llm/stream-handler.tap.js
@@ -53,13 +53,6 @@ tap.beforeEach((t) => {
 
   t.context.chunks = [{ foo: 'foo' }]
 
-  t.context.metrics = {
-    'amazon-bedrock-invocationMetrics': {
-      inputTokenCount: 5,
-      outputTokenCount: 10
-    }
-  }
-
   /* eslint-disable prettier/prettier */ // It doesn't like the IIFE syntax
   t.context.stream = (async function* originalStream() {
     const encoder = new TextEncoder()
@@ -94,8 +87,6 @@ tap.test('handles claude streams', async (t) => {
   t.same(handler.response, {
     response: {
       headers: {
-        'x-amzn-bedrock-input-token-count': 5,
-        'x-amzn-bedrock-output-token-count': 10,
         'x-amzn-requestid': 'aws-req-1'
       },
       statusCode: 200
@@ -117,8 +108,6 @@ tap.test('handles claude streams', async (t) => {
   t.equal(br.finishReason, 'done')
   t.equal(br.requestId, 'aws-req-1')
   t.equal(br.statusCode, 200)
-  t.equal(br.inputTokenCount, 5)
-  t.equal(br.outputTokenCount, 10)
 })
 
 tap.test('handles cohere streams', async (t) => {
@@ -136,8 +125,6 @@ tap.test('handles cohere streams', async (t) => {
   t.same(handler.response, {
     response: {
       headers: {
-        'x-amzn-bedrock-input-token-count': 5,
-        'x-amzn-bedrock-output-token-count': 10,
         'x-amzn-requestid': 'aws-req-1'
       },
       statusCode: 200
@@ -166,8 +153,6 @@ tap.test('handles cohere streams', async (t) => {
   t.equal(br.finishReason, 'done')
   t.equal(br.requestId, 'aws-req-1')
   t.equal(br.statusCode, 200)
-  t.equal(br.inputTokenCount, 5)
-  t.equal(br.outputTokenCount, 10)
 })
 
 tap.test('handles cohere embedding streams', async (t) => {
@@ -190,8 +175,6 @@ tap.test('handles cohere embedding streams', async (t) => {
   t.same(handler.response, {
     response: {
       headers: {
-        'x-amzn-bedrock-input-token-count': 5,
-        'x-amzn-bedrock-output-token-count': 10,
         'x-amzn-requestid': 'aws-req-1'
       },
       statusCode: 200
@@ -220,8 +203,6 @@ tap.test('handles cohere embedding streams', async (t) => {
   t.equal(br.finishReason, undefined)
   t.equal(br.requestId, 'aws-req-1')
   t.equal(br.statusCode, 200)
-  t.equal(br.inputTokenCount, 5)
-  t.equal(br.outputTokenCount, 10)
 })
 
 tap.test('handles llama2 streams', async (t) => {
@@ -239,8 +220,6 @@ tap.test('handles llama2 streams', async (t) => {
   t.same(handler.response, {
     response: {
       headers: {
-        'x-amzn-bedrock-input-token-count': 5,
-        'x-amzn-bedrock-output-token-count': 10,
         'x-amzn-requestid': 'aws-req-1'
       },
       statusCode: 200
@@ -262,8 +241,6 @@ tap.test('handles llama2 streams', async (t) => {
   t.equal(br.finishReason, 'done')
   t.equal(br.requestId, 'aws-req-1')
   t.equal(br.statusCode, 200)
-  t.equal(br.inputTokenCount, 5)
-  t.equal(br.outputTokenCount, 10)
 })
 
 tap.test('handles titan streams', async (t) => {
@@ -281,8 +258,6 @@ tap.test('handles titan streams', async (t) => {
   t.same(handler.response, {
     response: {
       headers: {
-        'x-amzn-bedrock-input-token-count': 5,
-        'x-amzn-bedrock-output-token-count': 10,
         'x-amzn-requestid': 'aws-req-1'
       },
       statusCode: 200
@@ -314,6 +289,4 @@ tap.test('handles titan streams', async (t) => {
   t.equal(br.finishReason, 'done')
   t.equal(br.requestId, 'aws-req-1')
   t.equal(br.statusCode, 200)
-  t.equal(br.inputTokenCount, 5)
-  t.equal(br.outputTokenCount, 10)
 })

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -83,7 +83,6 @@ function assertChatCompletionMessages({ tx, chatMsgs, expectedId, modelId, promp
     'request_id': 'eda0760a-c3f0-4fc1-9a1e-75559d642866',
     'trace_id': tx.traceId,
     'span_id': tx.trace.root.children[0].id,
-    'transaction_id': tx.id,
     'response.model': modelId,
     'vendor': 'bedrock',
     'ingest_source': 'Node',
@@ -118,22 +117,14 @@ function assertChatCompletionMessages({ tx, chatMsgs, expectedId, modelId, promp
   })
 }
 
-function assertChatCompletionSummary({
-  tx,
-  modelId,
-  chatSummary,
-  tokenUsage,
-  error = false,
-  numMsgs = 2
-}) {
-  let expectedChatSummary = {
+function assertChatCompletionSummary({ tx, modelId, chatSummary, error = false, numMsgs = 2 }) {
+  const expectedChatSummary = {
     'id': /[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}/,
     'appName': 'New Relic for Node.js tests',
     'request_id': 'eda0760a-c3f0-4fc1-9a1e-75559d642866',
     'llm.conversation_id': 'convo-id',
     'trace_id': tx.traceId,
     'span_id': tx.trace.root.children[0].id,
-    'transaction_id': tx.id,
     'response.model': modelId,
     'vendor': 'bedrock',
     'ingest_source': 'Node',
@@ -144,15 +135,6 @@ function assertChatCompletionSummary({
     'request.temperature': 0.5,
     'request.max_tokens': 100,
     'error': error
-  }
-
-  if (tokenUsage) {
-    expectedChatSummary = {
-      ...expectedChatSummary,
-      'response.usage.total_tokens': 12,
-      'response.usage.prompt_tokens': 8,
-      'response.usage.completion_tokens': 4
-    }
   }
 
   this.equal(chatSummary[0].type, 'LlmChatCompletionSummary')

--- a/tests/versioned/v3/bedrock-chat-completions.tap.js
+++ b/tests/versioned/v3/bedrock-chat-completions.tap.js
@@ -144,7 +144,7 @@ tap.afterEach(async (t) => {
           chatMsgs
         })
 
-        t.llmSummary({ tx, modelId, chatSummary, tokenUsage: true })
+        t.llmSummary({ tx, modelId, chatSummary })
 
         tx.end()
         t.end()
@@ -189,7 +189,7 @@ tap.afterEach(async (t) => {
         chatMsgs
       })
 
-      t.llmSummary({ tx, modelId, chatSummary, tokenUsage: true, numMsgs: events.length - 1 })
+      t.llmSummary({ tx, modelId, chatSummary, numMsgs: events.length - 1 })
 
       tx.end()
       t.end()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
Removed attributes around legacy token counts on summary. I also fixed the embedding event to only calculate token_count if callabck is specified.  Lastly, removed `transaction_id` from all events.

## Related Issues
Closes #265
