### PR TITLE
chore: Revert "refactor: Updated aws sdk instrumentation to construct specs at instrumentation (#259)"

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -27,17 +27,16 @@ function grabLastUrlSegment(url = '/') {
 /**
  * Retrieves the db segment params from endpoint and command parameters
  *
- * @param {function} DatastoreParameters constructor of `shim.spec.DatastoreParameters`
  * @param {Object} endpoint instance of ddb endpoint
  * @param {Object} params parameters passed to a ddb command
  * @returns {Object}
  */
-function setDynamoParameters(DatastoreParameters, endpoint, params) {
-  return new DatastoreParameters({
+function setDynamoParameters(endpoint, params) {
+  return {
     host: endpoint && (endpoint.host || endpoint.hostname),
     port_path_or_id: (endpoint && endpoint.port) || 443,
     collection: (params && params.TableName) || UNKNOWN
-  })
+  }
 }
 
 module.exports = {

--- a/lib/v2/dynamodb.js
+++ b/lib/v2/dynamodb.js
@@ -43,16 +43,12 @@ function instrument(shim, AWS) {
       function wrapMethod(shim, original, operationName, args) {
         const params = args[0]
 
-        return new shim.specs.OperationSpec({
+        return {
           name: operationName,
-          parameters: setDynamoParameters(
-            shim.specs.params.DatastoreParameters,
-            this.endpoint,
-            params
-          ),
+          parameters: setDynamoParameters(this.endpoint, params),
           callback: shim.LAST,
           opaque: true
-        })
+        }
       }
     )
   })
@@ -74,16 +70,16 @@ function instrument(shim, AWS) {
       // the eventual cached endpoint to be hit is not known at this point.
       const endpoint = this.service && this.service.endpoint
 
-      return new shim.specs.OperationSpec({
+      return {
         name: dynamoOperation,
-        parameters: new shim.specs.params.DatastoreParameters({
-          host: endpoint?.host,
-          port_path_or_id: endpoint?.port,
-          collection: params?.TableName || 'Unknown'
-        }),
+        parameters: {
+          host: endpoint && endpoint.host,
+          port_path_or_id: endpoint && endpoint.port,
+          collection: (params && params.TableName) || 'Unknown'
+        },
         callback: shim.LAST,
         opaque: true
-      })
+      }
     }
   )
 }

--- a/lib/v2/sns.js
+++ b/lib/v2/sns.js
@@ -27,12 +27,12 @@ function instrument(shim, AWS) {
 }
 
 function wrapPublish(shim, original, name, args) {
-  return new shim.specs.MessageSpec({
+  return {
     callback: shim.LAST,
     destinationName: getDestinationName(args[0]),
     destinationType: shim.TOPIC,
     opaque: true
-  })
+  }
 }
 
 function getDestinationName({ TopicArn, TargetArn }) {

--- a/lib/v2/sqs.js
+++ b/lib/v2/sqs.js
@@ -38,10 +38,10 @@ function recordMessageApi(shim, original, name, args) {
   const params = args[0]
   const queueName = grabLastUrlSegment(params.QueueUrl)
 
-  return new shim.specs.MessageSpec({
+  return {
     callback: shim.LAST,
     destinationName: queueName,
     destinationType: shim.QUEUE,
     opaque: true
-  })
+  }
 }

--- a/lib/v3/bedrock.js
+++ b/lib/v3/bedrock.js
@@ -188,7 +188,7 @@ function getBedrockSpec({ commandName }, shim, _original, _name, args) {
   const bedrockCommand = new BedrockCommand(input)
   const { modelType } = bedrockCommand
 
-  return new shim.specs.RecorderSpec({
+  return {
     promise: true,
     name: `Llm/${modelType}/Bedrock/${commandName}`,
     // eslint-disable-next-line max-params
@@ -223,7 +223,7 @@ function getBedrockSpec({ commandName }, shim, _original, _name, args) {
         addLlmMeta({ agent, segment })
       }
     }
-  })
+  }
 }
 
 function handleResponse({ shim, err, response, segment, bedrockCommand, modelType }) {

--- a/lib/v3/dynamodb.js
+++ b/lib/v3/dynamodb.js
@@ -17,13 +17,13 @@ const { setDynamoParameters } = require('../util')
  */
 function getDynamoSpec(shim, original, name, args) {
   const [{ input }] = args
-  return new shim.specs.OperationSpec({
+  return {
     name: this.commandName,
-    parameters: setDynamoParameters(shim.specs.params.DatastoreParameters, this.endpoint, input),
+    parameters: setDynamoParameters(this.endpoint, input),
     callback: shim.LAST,
     opaque: true,
     promise: true
-  })
+  }
 }
 
 /**

--- a/lib/v3/sns.js
+++ b/lib/v3/sns.js
@@ -33,13 +33,13 @@ function snsMiddleware(shim, config, next, context) {
  */
 function getSnsSpec(shim, original, name, args) {
   const [command] = args
-  return new shim.specs.MessageSpec({
+  return {
     promise: true,
     callback: shim.LAST,
     destinationName: getDestinationName(command.input),
     destinationType: shim.TOPIC,
     opaque: true
-  })
+  }
 }
 
 /**

--- a/lib/v3/sqs.js
+++ b/lib/v3/sqs.js
@@ -42,12 +42,12 @@ function sqsMiddleware(shim, config, next, context) {
 function getSqsSpec(shim, original, name, args) {
   const [command] = args
   const { QueueUrl } = command.input
-  return new shim.specs.MessageSpec({
+  return {
     callback: shim.LAST,
     destinationName: grabLastUrlSegment(QueueUrl),
     destinationType: shim.QUEUE,
     opaque: true
-  })
+  }
 }
 
 module.exports.sqsMiddlewareConfig = {

--- a/tests/unit/util.tap.js
+++ b/tests/unit/util.tap.js
@@ -6,13 +6,6 @@
 'use strict'
 const tap = require('tap')
 const { grabLastUrlSegment, setDynamoParameters } = require('../../lib/util')
-
-function DatastoreParametersMock(params) {
-  this.host = params.host ?? null
-  this.port_path_or_id = params.port_path_or_id ?? null
-  this.database_name = params.database_name ?? null
-  this.collection = params.collection ?? null
-}
 tap.test('Utility Functions', (t) => {
   t.ok(grabLastUrlSegment, 'imported function successfully')
 
@@ -48,12 +41,11 @@ tap.test('DB parameters', (t) => {
   t.test('default values', (t) => {
     const input = {}
     const endpoint = {}
-    const result = setDynamoParameters(DatastoreParametersMock, endpoint, input)
+    const result = setDynamoParameters(endpoint, input)
     t.same(
       result,
       {
         host: undefined,
-        database_name: null,
         port_path_or_id: 443,
         collection: 'Unknown'
       },
@@ -66,12 +58,11 @@ tap.test('DB parameters', (t) => {
   t.test('host, port, collection', (t) => {
     const input = { TableName: 'unit-test' }
     const endpoint = { host: 'unit-test-host', port: '123' }
-    const result = setDynamoParameters(DatastoreParametersMock, endpoint, input)
+    const result = setDynamoParameters(endpoint, input)
     t.same(
       result,
       {
         host: endpoint.host,
-        database_name: null,
         port_path_or_id: endpoint.port,
         collection: input.TableName
       },
@@ -84,12 +75,11 @@ tap.test('DB parameters', (t) => {
   t.test('hostname, port, collection', (t) => {
     const input = { TableName: 'unit-test' }
     const endpoint = { hostname: 'unit-test-host', port: '123' }
-    const result = setDynamoParameters(DatastoreParametersMock, endpoint, input)
+    const result = setDynamoParameters(endpoint, input)
     t.same(
       result,
       {
         host: endpoint.hostname,
-        database_name: null,
         port_path_or_id: endpoint.port,
         collection: input.TableName
       },

--- a/tests/versioned/v3/bedrock-chat-completions.tap.js
+++ b/tests/versioned/v3/bedrock-chat-completions.tap.js
@@ -11,7 +11,6 @@ utils(tap)
 const common = require('../common')
 const createAiResponseServer = require('@newrelic/test-utilities/lib/bedrock-server')
 const { FAKE_CREDENTIALS } = require('../aws-server-stubs')
-const { version: pkgVersion } = require('@smithy/smithy-client/package.json')
 const { DESTINATIONS } = require('../../../lib/util')
 
 const requests = {
@@ -240,9 +239,11 @@ tap.afterEach(async (t) => {
     const { agent } = helper
     helper.runInTransaction(async (tx) => {
       await client.send(command)
-      const metrics = agent.metrics.getOrCreateMetric(
-        `Supportability/Nodejs/ML/Bedrock/${pkgVersion}`
-      )
+      const metrics = getPrefixedMetric({
+        agent,
+        metricPrefix: 'Supportability/Nodejs/ML/Bedrock'
+      })
+
       t.equal(metrics.callCount > 0, true)
       tx.end()
       t.end()
@@ -590,9 +591,10 @@ tap.test('should not instrument stream when disabled', (t) => {
     t.equal(events.length, 0, 'should not create Llm events when streaming is disabled')
     const attributes = tx.trace.attributes.get(DESTINATIONS.TRANS_EVENT)
     t.equal(attributes.llm, true, 'should assign llm attribute to transaction trace')
-    const metrics = agent.metrics.getOrCreateMetric(
-      `Supportability/Nodejs/ML/Bedrock/${pkgVersion}`
-    )
+    const metrics = getPrefixedMetric({
+      agent,
+      metricPrefix: 'Supportability/Nodejs/ML/Bedrock'
+    })
     t.equal(metrics.callCount > 0, true, 'should set framework metric')
     const supportabilityMetrics = agent.metrics.getOrCreateMetric(
       `Supportability/Nodejs/ML/Streaming/Disabled`
@@ -634,3 +636,13 @@ tap.test('should utilize tokenCountCallback when set', (t) => {
     t.end()
   })
 })
+
+// eslint-disable-next-line consistent-return
+function getPrefixedMetric({ agent, metricPrefix }) {
+  for (const [key, value] of Object.entries(agent.metrics._metrics.unscoped)) {
+    if (key.startsWith(metricPrefix) === false) {
+      continue
+    }
+    return value
+  }
+}

--- a/tests/versioned/v3/package.json
+++ b/tests/versioned/v3/package.json
@@ -180,9 +180,9 @@
       },
       "dependencies": {
         "@aws-sdk/util-dynamodb": "latest",
-        "@aws-sdk/client-dynamodb": "3.476.0",
+        "@aws-sdk/client-dynamodb": "latest",
         "@aws-sdk/lib-dynamodb": {
-          "versions": ">=3.0.0 <=3.193.0 || >3.196.0 <3.377.0 || >3.377.0 ",
+          "versions": ">3.377.0 ",
           "samples": 10
         }
       },


### PR DESCRIPTION
This reverts commit 94de4208ebbf1161c2c2aaf66aced97a45c610b8.

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We made a breaking change that affected customers on versions of agent < 11.11.0 and released as a minor.  Due to "reasons" we're backing this change out and plan on issuing a patch release to fix customers doing clean installs of agent < 11.11.0.  We have folded all of this code into the agent as of 11.16.0. 

## Additional Context
I also verified that backing this out will not affect customers running 11.15.0 which removed constructing specs in the agent by going to the `11.15.0` tag and adding this branch into versioned external

```diff --git a/test/versioned-external/external-repos.js b/test/versioned-external/external-repos.js
index 15f625fa3..c52fffd9a 100644
--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -15,7 +15,7 @@ const repos = [
   {
     name: 'aws-sdk',
     repository: 'https://github.com/newrelic/node-newrelic-aws-sdk.git',
-    branch: 'main'
+    branch: 'backout-spec-construction'
   },
```

and running `npm run versioned:external aws-sdk`


## Related Issues
 * #267
 * https://github.com/newrelic/node-newrelic/issues/2097

